### PR TITLE
Implement training service abstraction

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import cors from 'cors'
 import helmet from 'helmet'
 import trainingRoutes from './routes/training'
+import { errorHandler } from './middleware/errorHandler'
 
 const app = express()
 const PORT = process.env.PORT || 3001
@@ -51,15 +52,7 @@ app.use('*', (req, res) => {
 })
 
 // Error handler
-app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-  // eslint-disable-next-line no-console
-  console.error('Error:', err.message)
-  res.status(500).json({
-    error: 'Internal Server Error',
-    message: process.env.NODE_ENV === 'development' ? err.message : 'Something went wrong',
-    timestamp: new Date().toISOString()
-  })
-})
+app.use(errorHandler)
 
 // Start server
 const server = app.listen(PORT, () => {

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,9 @@
+import type { Request, Response, NextFunction } from 'express'
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  // eslint-disable-next-line no-console
+  console.error('Error:', err)
+  const status = (err as any)?.status ?? 500
+  const message = status === 500 ? 'Internal Server Error' : err.message
+  res.status(status).json({ success: false, error: message })
+}

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -1,17 +1,15 @@
 import { Router } from 'express'
-import { eq, desc, and } from 'drizzle-orm'
 import { z } from 'zod'
-import { db, trainingModules, trainingAssignments, users } from '../db'
+import { DbTrainingService } from '../services/dbTrainingService'
 import { MockTrainingService } from '../services/mockTrainingService'
+import type { TrainingService } from '../services/TrainingService'
 
 const router = Router()
 
-// Initialize mock service for development
-const mockService = new MockTrainingService()
+const service: TrainingService = process.env.DATABASE_URL
+  ? new DbTrainingService()
+  : new MockTrainingService()
 
-// Helper function removed - was unused
-
-// Validation schemas
 const createModuleSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z.string().optional(),
@@ -28,419 +26,114 @@ const assignModuleSchema = z.object({
   dueDate: z.string().datetime().optional()
 })
 
-// GET /api/v1/training/modules - List all training modules
-router.get('/modules', async (_req, res) => {
+router.get('/modules', async (_req, res, next) => {
   try {
-    const modules = await db
-      .select({
-        id: trainingModules.id,
-        title: trainingModules.title,
-        description: trainingModules.description,
-        estimatedDuration: trainingModules.estimatedDuration,
-        status: trainingModules.status,
-        createdAt: trainingModules.createdAt,
-        creator: {
-          id: users.id,
-          name: users.name
-        }
-      })
-      .from(trainingModules)
-      .leftJoin(users, eq(trainingModules.createdBy, users.id))
-      .orderBy(desc(trainingModules.createdAt))
-
-    res.json({
-      success: true,
-      data: modules
-    })
-  } catch (error) {
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const modules = await mockService.getModules()
-      res.json(modules)
-    } catch (mockError) {
-      console.error('Error fetching training modules:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to fetch training modules'
-      })
-    }
+    const modules = await service.getModules()
+    res.json({ success: true, data: modules })
+  } catch (err) {
+    next(err)
   }
 })
 
-// GET /api/v1/training/modules/:id - Get specific training module
-router.get('/modules/:id', async (req, res) => {
+router.get('/modules/:id', async (req, res, next) => {
   try {
-    const { id } = req.params
-
-    const module = await db
-      .select()
-      .from(trainingModules)
-      .where(eq(trainingModules.id, id))
-      .limit(1)
-
-    if (module.length === 0) {
-      return res.status(404).json({
-        success: false,
-        error: 'Training module not found'
-      })
+    const module = await service.getModule(req.params.id)
+    if (!module) {
+      return res.status(404).json({ success: false, error: 'Training module not found' })
     }
-
-    res.json({
-      success: true,
-      data: module[0]
-    })
-  } catch (error) {
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const module = await mockService.getModule(req.params.id)
-      if (!module) {
-        return res.status(404).json({ error: 'Training module not found' })
-      }
-      res.json(module)
-    } catch (mockError) {
-      console.error('Error fetching training module:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to fetch training module'
-      })
-    }
+    res.json({ success: true, data: module })
+  } catch (err) {
+    next(err)
   }
 })
 
-// POST /api/v1/training/modules - Create new training module
-router.post('/modules', async (req, res) => {
+router.post('/modules', async (req, res, next) => {
   try {
-    const validatedData = createModuleSchema.parse(req.body)
-    
-    // In a real app, get user ID from JWT token
-    const createdBy = req.headers['x-user-id'] as string || 'system'
-    
-    const [newModule] = await db
-      .insert(trainingModules)
-      .values({
-        title: validatedData.title,
-        description: validatedData.description,
-        content: validatedData.content,
-        estimatedDuration: validatedData.estimatedDuration,
-        status: validatedData.status || 'draft',
-        createdBy
-      })
-      .returning()
-
-    res.status(201).json({
-      success: true,
-      data: newModule
-    })
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return res.status(400).json({
-        success: false,
-        error: 'Validation failed',
-        details: error.errors
-      })
+    const validated = createModuleSchema.parse(req.body)
+    const createdBy = (req.headers['x-user-id'] as string) || 'system'
+    const module = await service.createModule(validated, createdBy)
+    res.status(201).json({ success: true, data: module })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const newModule = await mockService.createModule(req.body)
-      res.status(201).json(newModule)
-    } catch (mockError) {
-      console.error('Error creating training module:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to create training module'
-      })
-    }
+    next(err)
   }
 })
 
-// PUT /api/v1/training/modules/:id - Update training module
-router.put('/modules/:id', async (req, res) => {
+router.put('/modules/:id', async (req, res, next) => {
   try {
-    const { id } = req.params
-    const validatedData = createModuleSchema.partial().parse(req.body)
-    
-    const [updatedModule] = await db
-      .update(trainingModules)
-      .set({
-        ...validatedData,
-        updatedAt: new Date()
-      })
-      .where(eq(trainingModules.id, id))
-      .returning()
-
-    if (!updatedModule) {
-      return res.status(404).json({
-        success: false,
-        error: 'Training module not found'
-      })
+    const validated = createModuleSchema.partial().parse(req.body)
+    const module = await service.updateModule(req.params.id, validated)
+    if (!module) {
+      return res.status(404).json({ success: false, error: 'Training module not found' })
     }
-
-    res.json({
-      success: true,
-      data: updatedModule
-    })
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return res.status(400).json({
-        success: false,
-        error: 'Validation failed',
-        details: error.errors
-      })
+    res.json({ success: true, data: module })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const updatedModule = await mockService.updateModule(req.params.id, req.body)
-      if (!updatedModule) {
-        return res.status(404).json({ error: 'Training module not found' })
-      }
-      res.json(updatedModule)
-    } catch (mockError) {
-      console.error('Error updating training module:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to update training module'
-      })
-    }
+    next(err)
   }
 })
 
-// DELETE /api/v1/training/modules/:id - Delete training module
-router.delete('/modules/:id', async (req, res) => {
+router.delete('/modules/:id', async (req, res, next) => {
   try {
-    const { id } = req.params
-
-    const [deletedModule] = await db
-      .delete(trainingModules)
-      .where(eq(trainingModules.id, id))
-      .returning()
-
-    if (!deletedModule) {
-      return res.status(404).json({
-        success: false,
-        error: 'Training module not found'
-      })
+    const deleted = await service.deleteModule(req.params.id)
+    if (!deleted) {
+      return res.status(404).json({ success: false, error: 'Training module not found' })
     }
-
-    res.json({
-      success: true,
-      message: 'Training module deleted successfully'
-    })
-  } catch (error) {
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const deleted = await mockService.deleteModule(req.params.id)
-      if (!deleted) {
-        return res.status(404).json({ error: 'Training module not found' })
-      }
-      res.status(204).send()
-    } catch (mockError) {
-      console.error('Error deleting training module:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to delete training module'
-      })
-    }
+    res.json({ success: true, message: 'Training module deleted successfully' })
+  } catch (err) {
+    next(err)
   }
 })
 
-// POST /api/v1/training/assign - Assign training module to users
-router.post('/assign', async (req, res) => {
+router.post('/assign', async (req, res, next) => {
   try {
-    const validatedData = assignModuleSchema.parse(req.body)
-    const assignedBy = req.headers['x-user-id'] as string || 'system'
-    
-    const assignments = validatedData.assignedTo.map(userId => ({
-      moduleId: validatedData.moduleId,
-      assignedTo: userId,
-      assignedBy,
-      dueDate: validatedData.dueDate ? new Date(validatedData.dueDate) : null,
-      status: 'pending' as const
-    }))
-
-    const newAssignments = await db
-      .insert(trainingAssignments)
-      .values(assignments)
-      .returning()
-
-    res.status(201).json({
-      success: true,
-      data: newAssignments
-    })
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return res.status(400).json({
-        success: false,
-        error: 'Validation failed',
-        details: error.errors
-      })
+    const validated = assignModuleSchema.parse(req.body)
+    const assignedBy = (req.headers['x-user-id'] as string) || 'system'
+    const result = await service.assignModule(validated, assignedBy)
+    res.status(201).json({ success: true, data: result })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const result = await mockService.assignModule()
-      res.status(201).json(result)
-    } catch (mockError) {
-      console.error('Error assigning training module:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to assign training module'
-      })
-    }
+    next(err)
   }
 })
 
-// GET /api/v1/training/assignments - Get training assignments for a user
-router.get('/assignments', async (req, res) => {
+router.get('/assignments', async (req, res, next) => {
   try {
     const userId = req.headers['x-user-id'] as string
-
     if (!userId) {
-      return res.status(401).json({
-        success: false,
-        error: 'User ID required'
-      })
+      return res.status(401).json({ success: false, error: 'User ID required' })
     }
-
-    const assignments = await db
-      .select({
-        id: trainingAssignments.id,
-        status: trainingAssignments.status,
-        dueDate: trainingAssignments.dueDate,
-        startedAt: trainingAssignments.startedAt,
-        completedAt: trainingAssignments.completedAt,
-        score: trainingAssignments.score,
-        module: {
-          id: trainingModules.id,
-          title: trainingModules.title,
-          description: trainingModules.description,
-          estimatedDuration: trainingModules.estimatedDuration
-        }
-      })
-      .from(trainingAssignments)
-      .innerJoin(trainingModules, eq(trainingAssignments.moduleId, trainingModules.id))
-      .where(eq(trainingAssignments.assignedTo, userId))
-      .orderBy(desc(trainingAssignments.createdAt))
-
-    res.json({
-      success: true,
-      data: assignments
-    })
-  } catch (error) {
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const assignments = await mockService.getMyAssignments()
-      res.json(assignments)
-    } catch (mockError) {
-      console.error('Error fetching training assignments:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to fetch training assignments'
-      })
-    }
+    const assignments = await service.getMyAssignments(userId)
+    res.json({ success: true, data: assignments })
+  } catch (err) {
+    next(err)
   }
 })
 
-// PUT /api/v1/training/assignments/:id/start - Start a training assignment
-router.put('/assignments/:id/start', async (req, res) => {
+router.put('/assignments/:id/start', async (req, res, next) => {
   try {
-    const { id } = req.params
     const userId = req.headers['x-user-id'] as string
-
-    const [updatedAssignment] = await db
-      .update(trainingAssignments)
-      .set({
-        status: 'in_progress',
-        startedAt: new Date(),
-        updatedAt: new Date()
-      })
-      .where(and(
-        eq(trainingAssignments.id, id),
-        eq(trainingAssignments.assignedTo, userId)
-      ))
-      .returning()
-
-    if (!updatedAssignment) {
-      return res.status(404).json({
-        success: false,
-        error: 'Training assignment not found'
-      })
-    }
-
-    res.json({
-      success: true,
-      data: updatedAssignment
-    })
-  } catch (error) {
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const result = await mockService.startAssignment()
-      res.json(result)
-    } catch (mockError) {
-      console.error('Error starting training assignment:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to start training assignment'
-      })
-    }
+    const assignment = await service.startAssignment(req.params.id, userId)
+    res.json({ success: true, data: assignment })
+  } catch (err) {
+    next(err)
   }
 })
 
-// PUT /api/v1/training/assignments/:id/complete - Complete a training assignment
-router.put('/assignments/:id/complete', async (req, res) => {
+router.put('/assignments/:id/complete', async (req, res, next) => {
   try {
-    const { id } = req.params
-    const { score } = req.body
     const userId = req.headers['x-user-id'] as string
-
-    const [updatedAssignment] = await db
-      .update(trainingAssignments)
-      .set({
-        status: 'completed',
-        completedAt: new Date(),
-        score: score || null,
-        updatedAt: new Date()
-      })
-      .where(and(
-        eq(trainingAssignments.id, id),
-        eq(trainingAssignments.assignedTo, userId)
-      ))
-      .returning()
-
-    if (!updatedAssignment) {
-      return res.status(404).json({
-        success: false,
-        error: 'Training assignment not found'
-      })
-    }
-
-    res.json({
-      success: true,
-      data: updatedAssignment
-    })
-  } catch (error) {
-    // Fallback to mock service if database fails
-    console.warn('Database unavailable, using mock service:', error)
-    try {
-      const result = await mockService.completeAssignment()
-      res.json(result)
-    } catch (mockError) {
-      console.error('Error completing training assignment:', mockError)
-      res.status(500).json({
-        success: false,
-        error: 'Failed to complete training assignment'
-      })
-    }
+    const assignment = await service.completeAssignment(req.params.id, userId, req.body)
+    res.json({ success: true, data: assignment })
+  } catch (err) {
+    next(err)
   }
 })
 
-export default router 
+export default router

--- a/server/src/services/TrainingService.ts
+++ b/server/src/services/TrainingService.ts
@@ -1,0 +1,22 @@
+import {
+  TrainingModuleListItem,
+  TrainingModule,
+  TrainingAssignmentWithModule,
+  CreateTrainingModuleRequest,
+  UpdateTrainingModuleRequest,
+  AssignTrainingModuleRequest,
+  CompleteTrainingAssignmentRequest,
+  TrainingAssignment
+} from '@shared/types/training'
+
+export interface TrainingService {
+  getModules(): Promise<TrainingModuleListItem[]>
+  getModule(id: string): Promise<TrainingModule | null>
+  createModule(data: CreateTrainingModuleRequest & { status?: string }, createdBy?: string): Promise<TrainingModule>
+  updateModule(id: string, data: UpdateTrainingModuleRequest): Promise<TrainingModule | null>
+  deleteModule(id: string): Promise<boolean>
+  assignModule(data: AssignTrainingModuleRequest, assignedBy: string): Promise<TrainingAssignment[] | { success: boolean; message: string }>
+  getMyAssignments(userId: string): Promise<TrainingAssignmentWithModule[]>
+  startAssignment(id: string, userId: string): Promise<TrainingAssignment | { success: boolean; message: string }>
+  completeAssignment(id: string, userId: string, data: CompleteTrainingAssignmentRequest): Promise<TrainingAssignment | { success: boolean; message: string }>
+}

--- a/server/src/services/dbTrainingService.ts
+++ b/server/src/services/dbTrainingService.ts
@@ -1,0 +1,164 @@
+import { and, desc, eq } from 'drizzle-orm'
+import { db, trainingModules, trainingAssignments, users } from '../db'
+import {
+  TrainingService
+} from './TrainingService'
+import {
+  CreateTrainingModuleRequest,
+  UpdateTrainingModuleRequest,
+  AssignTrainingModuleRequest,
+  CompleteTrainingAssignmentRequest,
+  TrainingModule,
+  TrainingModuleListItem,
+  TrainingAssignment,
+  TrainingAssignmentWithModule
+} from '@shared/types/training'
+
+export class DbTrainingService implements TrainingService {
+  async getModules(): Promise<TrainingModuleListItem[]> {
+    const modules = await db
+      .select({
+        id: trainingModules.id,
+        title: trainingModules.title,
+        description: trainingModules.description,
+        estimatedDuration: trainingModules.estimatedDuration,
+        status: trainingModules.status,
+        createdAt: trainingModules.createdAt,
+        creator: {
+          id: users.id,
+          name: users.name
+        }
+      })
+      .from(trainingModules)
+      .leftJoin(users, eq(trainingModules.createdBy, users.id))
+      .orderBy(desc(trainingModules.createdAt))
+
+    return modules as unknown as TrainingModuleListItem[]
+  }
+
+  async getModule(id: string): Promise<TrainingModule | null> {
+    const module = await db
+      .select()
+      .from(trainingModules)
+      .where(eq(trainingModules.id, id))
+      .limit(1)
+
+    return module[0] as unknown as TrainingModule || null
+  }
+
+  async createModule(data: CreateTrainingModuleRequest & { status?: string }, createdBy?: string): Promise<TrainingModule> {
+    const [newModule] = await db
+      .insert(trainingModules)
+      .values({
+        title: data.title,
+        description: data.description,
+        content: data.content,
+        estimatedDuration: data.estimatedDuration,
+        status: data.status || 'draft',
+        createdBy
+      })
+      .returning()
+
+    return newModule as unknown as TrainingModule
+  }
+
+  async updateModule(id: string, data: UpdateTrainingModuleRequest): Promise<TrainingModule | null> {
+    const [updatedModule] = await db
+      .update(trainingModules)
+      .set({
+        ...data,
+        updatedAt: new Date()
+      })
+      .where(eq(trainingModules.id, id))
+      .returning()
+
+    return updatedModule as unknown as TrainingModule || null
+  }
+
+  async deleteModule(id: string): Promise<boolean> {
+    const [deletedModule] = await db
+      .delete(trainingModules)
+      .where(eq(trainingModules.id, id))
+      .returning()
+
+    return !!deletedModule
+  }
+
+  async assignModule(data: AssignTrainingModuleRequest, assignedBy: string): Promise<TrainingAssignment[]> {
+    const assignments = data.assignedTo.map(userId => ({
+      moduleId: data.moduleId,
+      assignedTo: userId,
+      assignedBy,
+      dueDate: data.dueDate ? new Date(data.dueDate) : null,
+      status: 'pending' as const
+    }))
+
+    const newAssignments = await db
+      .insert(trainingAssignments)
+      .values(assignments)
+      .returning()
+
+    return newAssignments as unknown as TrainingAssignment[]
+  }
+
+  async getMyAssignments(userId: string): Promise<TrainingAssignmentWithModule[]> {
+    const assignments = await db
+      .select({
+        id: trainingAssignments.id,
+        status: trainingAssignments.status,
+        dueDate: trainingAssignments.dueDate,
+        startedAt: trainingAssignments.startedAt,
+        completedAt: trainingAssignments.completedAt,
+        score: trainingAssignments.score,
+        module: {
+          id: trainingModules.id,
+          title: trainingModules.title,
+          description: trainingModules.description,
+          estimatedDuration: trainingModules.estimatedDuration
+        }
+      })
+      .from(trainingAssignments)
+      .innerJoin(trainingModules, eq(trainingAssignments.moduleId, trainingModules.id))
+      .where(eq(trainingAssignments.assignedTo, userId))
+      .orderBy(desc(trainingAssignments.createdAt))
+
+    return assignments as unknown as TrainingAssignmentWithModule[]
+  }
+
+  async startAssignment(id: string, userId: string): Promise<TrainingAssignment> {
+    const [updated] = await db
+      .update(trainingAssignments)
+      .set({
+        status: 'in_progress',
+        startedAt: new Date(),
+        updatedAt: new Date()
+      })
+      .where(and(eq(trainingAssignments.id, id), eq(trainingAssignments.assignedTo, userId)))
+      .returning()
+
+    if (!updated) {
+      throw new Error('Training assignment not found')
+    }
+
+    return updated as unknown as TrainingAssignment
+  }
+
+  async completeAssignment(id: string, userId: string, data: CompleteTrainingAssignmentRequest): Promise<TrainingAssignment> {
+    const [updated] = await db
+      .update(trainingAssignments)
+      .set({
+        status: 'completed',
+        completedAt: new Date(),
+        score: data.score || null,
+        updatedAt: new Date()
+      })
+      .where(and(eq(trainingAssignments.id, id), eq(trainingAssignments.assignedTo, userId)))
+      .returning()
+
+    if (!updated) {
+      throw new Error('Training assignment not found')
+    }
+
+    return updated as unknown as TrainingAssignment
+  }
+}

--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -1,3 +1,15 @@
+import { TrainingService } from './TrainingService'
+import {
+  CreateTrainingModuleRequest,
+  UpdateTrainingModuleRequest,
+  AssignTrainingModuleRequest,
+  CompleteTrainingAssignmentRequest,
+  TrainingModule,
+  TrainingModuleListItem,
+  TrainingAssignment,
+  TrainingAssignmentWithModule
+} from '@shared/types/training'
+
 // Mock data for development
 const mockModules = [
   {
@@ -76,10 +88,10 @@ const mockModules = [
   }
 ]
 
-export class MockTrainingService {
+export class MockTrainingService implements TrainingService {
   private modules = [...mockModules]
 
-  async getModules() {
+  async getModules(): Promise<TrainingModuleListItem[]> {
     // Simulate API delay
     await new Promise(resolve => setTimeout(resolve, 300))
     
@@ -95,12 +107,12 @@ export class MockTrainingService {
     }))
   }
 
-  async getModule(id: string) {
+  async getModule(id: string): Promise<TrainingModule | null> {
     await new Promise(resolve => setTimeout(resolve, 200))
     return this.modules.find(module => module.id === id) || null
   }
 
-  async createModule(data: any) {
+  async createModule(data: CreateTrainingModuleRequest & { status?: string }): Promise<TrainingModule> {
     await new Promise(resolve => setTimeout(resolve, 400))
     
     const newModule = {
@@ -123,7 +135,7 @@ export class MockTrainingService {
     return newModule
   }
 
-  async updateModule(id: string, data: any) {
+  async updateModule(id: string, data: UpdateTrainingModuleRequest): Promise<TrainingModule | null> {
     await new Promise(resolve => setTimeout(resolve, 400))
     
     const moduleIndex = this.modules.findIndex(module => module.id === id)
@@ -149,23 +161,23 @@ export class MockTrainingService {
     return true
   }
 
-  async getMyAssignments() {
+  async getMyAssignments(_userId: string): Promise<TrainingAssignmentWithModule[]> {
     // Mock assignments for development
     await new Promise(resolve => setTimeout(resolve, 200))
     return []
   }
 
-  async assignModule() {
+  async assignModule(_data: AssignTrainingModuleRequest, _assignedBy: string): Promise<{ success: boolean; message: string }> {
     await new Promise(resolve => setTimeout(resolve, 300))
     return { success: true, message: 'Module assigned successfully' }
   }
 
-  async startAssignment() {
+  async startAssignment(_id: string, _userId: string): Promise<{ success: boolean; message: string }> {
     await new Promise(resolve => setTimeout(resolve, 200))
     return { success: true, message: 'Assignment started' }
   }
 
-  async completeAssignment() {
+  async completeAssignment(_id: string, _userId: string, _data: CompleteTrainingAssignmentRequest): Promise<{ success: boolean; message: string }> {
     await new Promise(resolve => setTimeout(resolve, 300))
     return { success: true, message: 'Assignment completed' }
   }


### PR DESCRIPTION
## Summary
- add `TrainingService` interface and mock/db implementations
- centralize error handling middleware
- simplify training routes to use service layer

## Testing
- `npm run lint --workspace=server` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check --workspace=server` *(fails: command failed)*
- `npm run test --workspace=server` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572b900358832d847fc007c5333ca1