### PR TITLE
Replace clsx with cn utility

### DIFF
--- a/client/src/components/Badge.tsx
+++ b/client/src/components/Badge.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { clsx } from 'clsx'
+import { cn } from '../utils/cn'
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: 'default' | 'success' | 'warning' | 'error'
@@ -18,7 +18,7 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
     return (
       <span
         ref={ref}
-        className={clsx(
+        className={cn(
           'inline-flex items-center',
           'px-2.5 py-0.5',
           'rounded-full',

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { clsx } from 'clsx'
+import { cn } from '../utils/cn'
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'ghost'
@@ -53,7 +53,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={isDisabled}
         aria-label={ariaLabel}
         aria-disabled={isDisabled}
-        className={clsx(
+        className={cn(
           buttonBase,
           buttonVariants[variant],
           buttonSizes[size],

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { clsx } from 'clsx'
+import { cn } from '../utils/cn'
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
@@ -39,7 +39,7 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
         ref={ref}
         role={isInteractive ? 'button' : undefined}
         tabIndex={isInteractive ? 0 : undefined}
-        className={clsx(
+        className={cn(
           cardVariants.base,
           hover && cardVariants.hoverable,
           isInteractive ? cardVariants.interactive : cardVariants.nonInteractive,

--- a/client/src/components/IconWrapper.tsx
+++ b/client/src/components/IconWrapper.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { clsx } from 'clsx'
+import { cn } from '../utils/cn'
 
 export interface IconWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'default' | 'filled'
@@ -23,7 +23,7 @@ export const IconWrapper = React.forwardRef<HTMLDivElement, IconWrapperProps>(
     return (
       <div
         ref={ref}
-        className={clsx(
+        className={cn(
           'inline-flex items-center justify-center',
           'rounded-md',
           'transition-colors duration-150',

--- a/client/src/components/KpiTile.tsx
+++ b/client/src/components/KpiTile.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { clsx } from 'clsx'
+import { cn } from '../utils/cn'
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react'
 
 export interface KpiTileProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -30,7 +30,7 @@ export const KpiTile = React.forwardRef<HTMLDivElement, KpiTileProps>(
       return (
         <div
           ref={ref}
-          className={clsx(
+          className={cn(
             'card-base p-6 h-tile',
             'animate-pulse',
             className
@@ -47,7 +47,7 @@ export const KpiTile = React.forwardRef<HTMLDivElement, KpiTileProps>(
     return (
       <div
         ref={ref}
-        className={clsx(
+        className={cn(
           'card-base p-6 h-tile',
           'flex flex-col justify-between',
           className
@@ -60,7 +60,7 @@ export const KpiTile = React.forwardRef<HTMLDivElement, KpiTileProps>(
         </div>
         
         {change && TrendIcon && (
-          <div className={clsx('flex items-center text-sm', trendColors[trend])}>
+          <div className={cn('flex items-center text-sm', trendColors[trend])}>
             <TrendIcon 
               className="h-4 w-4 mr-1" 
               aria-label={`${trend === 'up' ? 'Increase' : trend === 'down' ? 'Decrease' : 'No change'}`}


### PR DESCRIPTION
## Summary
- use `cn` helper in Badge, Button, Card, IconWrapper, and KpiTile components
- keep class name merging consistent using the cn utility

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68572b96837c832da0760634754be4b8