### PR TITLE
Init dotenv and document env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# KitchenCoach 2.0
+
+This monorepo contains the web client, server API and shared utilities for the KitchenCoach 2.0 platform.
+
+## Getting Started
+
+Install dependencies from the root of the repository:
+
+```bash
+npm ci
+```
+
+During development you can start both the client and server with:
+
+```bash
+npm run dev
+```
+
+## Environment Variables
+
+The API server requires several environment variables. Create a `.env` file in the repository root and define the following values:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | Port for the Express server | `3001` |
+| `CLIENT_URL` | Allowed origin for CORS requests | `http://localhost:5173` |
+| `DATABASE_URL` | PostgreSQL connection string | `postgresql://dev:dev@localhost:5432/kitchencoach_dev` |
+| `NODE_ENV` | Node environment (development/production) | `development` |
+
+Other features such as email or SMS integrations may require additional variables which will be documented alongside those features.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,10 @@
+import dotenv from 'dotenv'
 import express from 'express'
 import cors from 'cors'
 import helmet from 'helmet'
 import trainingRoutes from './routes/training'
+
+dotenv.config()
 
 const app = express()
 const PORT = process.env.PORT || 3001


### PR DESCRIPTION
## Summary
- load environment variables in the API entrypoint
- add repository README with setup instructions and documented env vars

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572e333504832dbb250eeb07fec515