### PR TITLE
Add training routes test

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/index.js",
     "lint": "eslint . --max-warnings 0",
     "type-check": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest run",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/db/migrate.ts",
     "db:studio": "drizzle-kit studio"

--- a/server/src/__tests__/trainingRoutes.test.ts
+++ b/server/src/__tests__/trainingRoutes.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest"
+import request from 'supertest'
+import express from 'express'
+
+// set invalid database url before importing routes so db connection fails
+process.env.DATABASE_URL = 'postgresql://invalidHost:5432/invalidDb'
+
+import trainingRoutes from '../routes/training'
+
+const app = express()
+app.use(express.json())
+app.use('/api/v1/training', trainingRoutes)
+
+describe('Training routes', () => {
+  it('GET /api/v1/training/modules returns modules from mock service', async () => {
+    const res = await request(app).get('/api/v1/training/modules')
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body)).toBe(true)
+    expect(res.body.length).toBeGreaterThan(0)
+    expect(res.body[0]).toHaveProperty('id')
+    expect(res.body[0]).toHaveProperty('title')
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest + supertest test for training modules route
- run tests in non-watch mode

## Testing
- `npm run test --workspace=server`

------
https://chatgpt.com/codex/tasks/task_e_68572e3a2864832db26b9c4642b6b9f1