### PR TITLE
Set display name for ContextButton

### DIFF
--- a/client/src/components/ContextButton.tsx
+++ b/client/src/components/ContextButton.tsx
@@ -138,4 +138,6 @@ export const ContextButton: React.FC<ContextButtonProps> = ({ className }) => {
       )}
     </div>
   )
-} 
+}
+
+ContextButton.displayName = 'ContextButton'


### PR DESCRIPTION
## Summary
- assign `ContextButton.displayName = 'ContextButton'`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572e3b000c832d93845bd71d2b2476