### PR TITLE
Rename draft training interface

### DIFF
--- a/client/src/components/TrainingModuleDialog.tsx
+++ b/client/src/components/TrainingModuleDialog.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
 import { useForm } from 'react-hook-form'
 import { Button } from './Button'
-import useTrainingStore, { TrainingModule } from '../store/useTrainingStore'
+import useTrainingStore, { DraftTrainingModule } from '../store/useTrainingStore'
 import { X, ChevronLeft, ChevronRight } from 'lucide-react'
 import { nanoid } from 'nanoid'
 
@@ -52,7 +52,7 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
   const steps = ['Module Details', 'Build Steps', 'Review & Save']
 
   const onSaveDraft = (data: FormData) => {
-    const module: TrainingModule = {
+    const module: DraftTrainingModule = {
       id: nanoid(),
       title: data.title,
       description: data.description || undefined,
@@ -81,7 +81,7 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
   }
 
   const onPublish = (data: FormData) => {
-    const module: TrainingModule = {
+    const module: DraftTrainingModule = {
       id: nanoid(),
       title: data.title,
       description: data.description || undefined,

--- a/client/src/store/useTrainingStore.ts
+++ b/client/src/store/useTrainingStore.ts
@@ -17,7 +17,9 @@ export interface TrainingStep {
   blocks: (ContentBlock | QuizBlock)[]
 }
 
-export interface TrainingModule {
+// Local draft representation separate from the shared TrainingModule type in
+// `shared` to keep this store self-contained
+export interface DraftTrainingModule {
   id: string
   title: string
   description?: string
@@ -26,10 +28,10 @@ export interface TrainingModule {
 }
 
 interface TrainingStore {
-  modules: TrainingModule[]
-  draftModules: TrainingModule[]
-  addDraft: (module: TrainingModule) => void
-  updateDraft: (id: string, partial: Partial<TrainingModule>) => void
+  modules: DraftTrainingModule[]
+  draftModules: DraftTrainingModule[]
+  addDraft: (module: DraftTrainingModule) => void
+  updateDraft: (id: string, partial: Partial<DraftTrainingModule>) => void
   publish: (id: string) => void
 }
 


### PR DESCRIPTION
## Summary
- rename local `TrainingModule` interface to `DraftTrainingModule`
- update store typings and dialog imports
- add comment referencing shared types

## Testing
- `npm run type-check`
- `npx vitest run` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68572b9d2348832da097bdd816d12e72