### PR TITLE
Update ESLint config environments

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,23 +20,17 @@ export default [
   },
   {
     files: ['**/*.{ts,tsx,js,jsx}'],
+    env: {
+      node: true,
+      browser: true,
+      es2020: true,
+    },
     languageOptions: {
       parser: tsparser,
       ecmaVersion: 2020,
       sourceType: 'module',
-              globals: {
-        window: 'readonly',
-        document: 'readonly',
-        console: 'readonly',
-        global: 'readonly',
-        process: 'readonly',
-        HTMLElement: 'readonly',
-        HTMLDivElement: 'readonly',
-        HTMLButtonElement: 'readonly',
-        HTMLSpanElement: 'readonly',
+      globals: {
         React: 'readonly',
-        MouseEvent: 'readonly',
-        Event: 'readonly',
       },
     },
     plugins: {


### PR DESCRIPTION
## Summary
- configure ESLint to use node, browser, and ES2020 environments
- prune redundant global declarations

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685763819848832db7e6b27ace81bdc0