### PR TITLE
Remove unused TrainingAssignment import

### DIFF
--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -6,7 +6,6 @@ import {
   CompleteTrainingAssignmentRequest,
   TrainingModule,
   TrainingModuleListItem,
-  TrainingAssignment,
   TrainingAssignmentWithModule
 } from '@shared/types/training'
 


### PR DESCRIPTION
## Summary
- clean up `mockTrainingService` imports

## Testing
- `npm run lint --workspace=server` *(fails: Cannot find package '@eslint/js')*
- `npm run test --workspace=server` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685763851ef8832d8f3ccbc1766c2c07