### PR TITLE
Update training module schema

### DIFF
--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -14,7 +14,15 @@ const createModuleSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z.string().optional(),
   content: z.object({
-    sections: z.array(z.any()).optional()
+    sections: z
+      .array(
+        z.object({
+          title: z.string(),
+          content: z.string(),
+          type: z.enum(['text', 'video', 'quiz', 'checklist'])
+        })
+      )
+      .optional()
   }),
   estimatedDuration: z.number().positive().optional(),
   status: z.enum(['draft', 'active', 'archived']).optional()


### PR DESCRIPTION
## Summary
- refine the `createModuleSchema` for training modules

## Testing
- `npm run lint --workspace=server` *(fails: eslint errors)*
- `npm run type-check --workspace=server` *(fails: tsc errors)*
- `npm run test --workspace=server` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685764215a18832d968ff06d71935a8e