### PR TITLE
Remove unused db:migrate script

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,6 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "tsx src/db/migrate.ts",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- clean up server package.json by removing `db:migrate`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68577e1c6b44832db66271f1c01b04d8