### PR TITLE
Update error handler typing

### DIFF
--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,9 +1,26 @@
 import type { Request, Response, NextFunction } from 'express'
 
-export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+interface StatusError {
+  status?: number
+  message?: string
+}
+
+export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction) {
   // eslint-disable-next-line no-console
   console.error('Error:', err)
-  const status = (err as any)?.status ?? 500
-  const message = status === 500 ? 'Internal Server Error' : err.message
+
+  let status = 500
+  let message = 'Internal Server Error'
+
+  if (typeof err === 'object' && err !== null) {
+    const e = err as StatusError
+    if (typeof e.status === 'number') {
+      status = e.status
+    }
+    if (typeof e.message === 'string' && status !== 500) {
+      message = e.message
+    }
+  }
+
   res.status(status).json({ success: false, error: message })
 }


### PR DESCRIPTION
## Summary
- improve typing for Express error middleware

## Testing
- `npm run type-check` *(fails: TS6059 shared file outside rootDir)*
- `npm test` *(fails: training route test assertion)*


------
https://chatgpt.com/codex/tasks/task_e_68577e1dc94c832da2e5b5e158618e12