### PR TITLE
Resolve TODOs in training pages

### DIFF
--- a/client/src/components/TrainingModuleCard.tsx
+++ b/client/src/components/TrainingModuleCard.tsx
@@ -60,8 +60,7 @@ export const TrainingModuleCard: React.FC<TrainingModuleCardProps> = ({
           )}
           <span className="flex items-center gap-1">
             <Users className="w-4 h-4" />
-            {/* TODO: Add enrollment count from API */}
-            0 enrolled
+            {module.enrollmentCount ?? 0} enrolled
           </span>
         </div>
         {module.creator && (

--- a/client/src/pages/Training.tsx
+++ b/client/src/pages/Training.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Card } from '../components/Card'
 import { Button } from '../components/Button'
 import { TrainingModuleCard } from '../components/TrainingModuleCard'
@@ -18,14 +19,14 @@ export const Training: React.FC = () => {
   
   const deleteModuleMutation = useDeleteTrainingModule()
 
+  const navigate = useNavigate()
+
   const handleStartTraining = (moduleId: string) => {
-    // TODO: Navigate to training module viewer
-    console.log('Starting training module:', moduleId)
+    navigate(`/training/modules/${moduleId}`)
   }
 
   const handleEditModule = (moduleId: string) => {
-    // TODO: Navigate to training module editor
-    console.log('Editing training module:', moduleId)
+    navigate(`/training/modules/${moduleId}/edit`)
   }
 
   const handleDeleteModule = async (moduleId: string) => {
@@ -34,7 +35,7 @@ export const Training: React.FC = () => {
         await deleteModuleMutation.mutateAsync(moduleId)
       } catch (error) {
         console.error('Failed to delete training module:', error)
-        // TODO: Show error toast
+        alert('Failed to delete training module. Please try again.')
       }
     }
   }

--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -31,6 +31,7 @@ const mockModules = [
     },
     status: 'active' as const,
     estimatedDuration: 45,
+    enrollmentCount: 0,
     createdAt: '2024-01-15T00:00:00.000Z',
     updatedAt: '2024-01-15T00:00:00.000Z',
     creator: {
@@ -54,6 +55,7 @@ const mockModules = [
     },
     status: 'draft' as const,
     estimatedDuration: 30,
+    enrollmentCount: 0,
     createdAt: '2024-01-20T00:00:00.000Z',
     updatedAt: '2024-01-20T00:00:00.000Z',
     creator: {
@@ -77,6 +79,7 @@ const mockModules = [
     },
     status: 'active' as const,
     estimatedDuration: 20,
+    enrollmentCount: 0,
     createdAt: '2024-01-10T00:00:00.000Z',
     updatedAt: '2024-01-10T00:00:00.000Z',
     creator: {
@@ -99,6 +102,7 @@ export class MockTrainingService implements TrainingService {
       title: module.title,
       description: module.description,
       status: module.status,
+      enrollmentCount: 0,
       estimatedDuration: module.estimatedDuration,
       createdAt: module.createdAt,
       updatedAt: module.updatedAt,

--- a/shared/src/types/training.ts
+++ b/shared/src/types/training.ts
@@ -29,6 +29,7 @@ export interface TrainingModuleListItem {
   title: string
   description?: string
   estimatedDuration?: number
+  enrollmentCount?: number
   status: TrainingStatus
   createdAt: string
   creator?: {


### PR DESCRIPTION
## Summary
- enable navigation for starting and editing a module
- show enrollment count in training module cards
- track mock enrollment counts
- add optional `enrollmentCount` to training types

## Testing
- `npm run lint` *(fails: A config object is using the "env" key)*
- `npm test` *(fails: Training routes test expects array response)*

------
https://chatgpt.com/codex/tasks/task_e_68577e1f06a8832d9fed4f4b4eae7eb3