### PR TITLE
Clean up duplicate error handler

### DIFF
--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,11 +1,5 @@
 import type { Request, Response, NextFunction } from 'express'
 
-export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
-  // eslint-disable-next-line no-console
-  console.error('Error:', err)
-  const status = (err as any)?.status ?? 500
-  const message = status === 500 ? 'Internal Server Error' : err.message
-
 interface StatusError {
   status?: number
   message?: string


### PR DESCRIPTION
## Summary
- remove stray initial error handler function
- keep single export of `errorHandler`

## Testing
- `npx tsc server/src/middleware/errorHandler.ts --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68579dabebb4832d9588f2ac85a1248e