### PR TITLE
Fix ESLint flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
+import globals from 'globals';
 
 export default [
   {
@@ -20,16 +21,14 @@ export default [
   },
   {
     files: ['**/*.{ts,tsx,js,jsx}'],
-    env: {
-      node: true,
-      browser: true,
-      es2020: true,
-    },
     languageOptions: {
       parser: tsparser,
       ecmaVersion: 2020,
       sourceType: 'module',
       globals: {
+        ...globals.es2020,
+        ...globals.node,
+        ...globals.browser,
         React: 'readonly',
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "axe-core": "^4.10.3",
         "concurrently": "^8.2.2",
         "eslint": "^8.57.0",
+        "globals": "^16.2.0",
         "lighthouse": "^12.6.1",
         "madge": "^8.0.0",
         "snyk": "^1.1297.2",
@@ -4720,6 +4721,22 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -11671,6 +11688,22 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -12677,16 +12710,13 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "axe-core": "^4.10.3",
     "concurrently": "^8.2.2",
     "eslint": "^8.57.0",
+    "globals": "^16.2.0",
     "lighthouse": "^12.6.1",
     "madge": "^8.0.0",
     "snyk": "^1.1297.2",


### PR DESCRIPTION
## Summary
- configure ESLint flat config without `env`
- add `globals` dev dependency for ESLint

## Testing
- `npm run lint` *(fails: too many warnings)*
- `npm test` *(fails to build tests)*

------
https://chatgpt.com/codex/tasks/task_e_6857a4c95b40832d9561b91b33acf1ea