### PR TITLE
Fix duplicated schema parsing in training routes

### DIFF
--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -59,9 +59,10 @@ router.get('/modules/:id', async (req, res, next) => {
 
 router.post('/modules', async (req, res, next) => {
   try {
-    const validated = createModuleSchema.parse(req.body)
-
-    const validated = createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & { status?: string }
+    const validated =
+      createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & {
+        status?: string
+      }
     const createdBy = (req.headers['x-user-id'] as string) || 'system'
     const module = await service.createModule(validated, createdBy)
     res.status(201).json({ success: true, data: module })
@@ -75,9 +76,8 @@ router.post('/modules', async (req, res, next) => {
 
 router.put('/modules/:id', async (req, res, next) => {
   try {
-    const validated = createModuleSchema.partial().parse(req.body)
-
-    const validated = createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest
+    const validated =
+      (createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest)
     const module = await service.updateModule(req.params.id, validated)
     if (!module) {
       return res.status(404).json({ success: false, error: 'Training module not found' })


### PR DESCRIPTION
## Summary
- remove duplicate schema parsing in POST/PUT module routes

## Testing
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68579dafc12c832db3888bc9303210bd