### PR TITLE
Add checklist builder with Zustand persistence

### DIFF
--- a/client/src/__tests__/ChecklistForm.test.tsx
+++ b/client/src/__tests__/ChecklistForm.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ChecklistForm } from '../components/checklists/ChecklistForm'
+
+describe('ChecklistForm', () => {
+  it('submits entered data', () => {
+    const handleSubmit = vi.fn()
+    render(<ChecklistForm onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByLabelText(/Checklist Title/i), { target: { value: 'Test' } })
+    fireEvent.change(screen.getAllByRole('textbox')[1], { target: { value: 'Item 1' } })
+    fireEvent.click(screen.getByLabelText('Weekly'))
+    fireEvent.click(screen.getByRole('button', { name: /Save Checklist/i }))
+
+    expect(handleSubmit).toHaveBeenCalled()
+    const values = handleSubmit.mock.calls[0][0]
+    expect(values.title).toBe('Test')
+    expect(values.schedule).toBe('weekly')
+    expect(values.items[0].text).toBe('Item 1')
+  })
+
+  it('adds new item field', () => {
+    render(<ChecklistForm onSubmit={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add Item' }))
+    expect(screen.getAllByRole('textbox')).toHaveLength(3)
+  })
+})

--- a/client/src/__tests__/ChecklistStore.test.ts
+++ b/client/src/__tests__/ChecklistStore.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import useChecklistStore from '../store/useChecklistStore'
+
+describe('useChecklistStore', () => {
+  beforeEach(() => {
+    useChecklistStore.setState({ drafts: [], runs: [] })
+    localStorage.clear()
+  })
+
+  it('adds a draft', () => {
+    useChecklistStore.getState().addDraft({ id: '1', title: 'A', items: [], frequency: 'daily' })
+    expect(useChecklistStore.getState().drafts).toHaveLength(1)
+  })
+
+  it('updates a draft', () => {
+    useChecklistStore.getState().addDraft({ id: '1', title: 'A', items: [], frequency: 'daily' })
+    useChecklistStore.getState().updateDraft('1', { title: 'B' })
+    expect(useChecklistStore.getState().drafts[0].title).toBe('B')
+  })
+
+  it('adds a run', () => {
+    useChecklistStore.getState().addRun({ id: 'r1', checklistId: '1', completedAt: 'now' })
+    expect(useChecklistStore.getState().runs).toHaveLength(1)
+  })
+})

--- a/client/src/__tests__/ScheduleSelector.test.tsx
+++ b/client/src/__tests__/ScheduleSelector.test.tsx
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ScheduleSelector } from '../components/checklists/ScheduleSelector'
+
+describe('ScheduleSelector', () => {
+  it('calls onChange with selected value', () => {
+    const fn = vi.fn()
+    render(<ScheduleSelector value="daily" onChange={fn} />)
+    fireEvent.click(screen.getByLabelText('Weekly'))
+    expect(fn).toHaveBeenCalledWith('weekly')
+  })
+})

--- a/client/src/components/checklists/ChecklistForm.tsx
+++ b/client/src/components/checklists/ChecklistForm.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react'
+import { nanoid } from 'nanoid'
+import { Button } from '../Button'
+import { ChecklistItemField } from './ChecklistItemField'
+import { ScheduleSelector } from './ScheduleSelector'
+
+export interface ChecklistItem {
+  id: string
+  text: string
+}
+
+export interface ChecklistFormValues {
+  id: string
+  title: string
+  schedule: 'daily' | 'weekly'
+  items: ChecklistItem[]
+}
+
+interface ChecklistFormProps {
+  initialValues?: Partial<ChecklistFormValues>
+  onSubmit: (values: ChecklistFormValues) => void
+}
+
+export const ChecklistForm: React.FC<ChecklistFormProps> = ({ initialValues, onSubmit }) => {
+  const [title, setTitle] = useState(initialValues?.title || '')
+  const [schedule, setSchedule] = useState<'daily' | 'weekly'>(initialValues?.schedule || 'daily')
+  const [items, setItems] = useState<ChecklistItem[]>(initialValues?.items || [{ id: nanoid(), text: '' }])
+
+  const addItem = () => setItems([...items, { id: nanoid(), text: '' }])
+  const updateItem = (id: string, text: string) => setItems(items.map(i => i.id === id ? { ...i, text } : i))
+  const removeItem = (id: string) => setItems(items.filter(i => i.id !== id))
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit({
+      id: initialValues?.id || nanoid(),
+      title,
+      schedule,
+      items: items.filter(i => i.text.trim() !== '')
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="cl-title" className="block text-sm font-medium mb-1">Checklist Title *</label>
+        <input
+          id="cl-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-orange"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Schedule *</label>
+        <ScheduleSelector value={schedule} onChange={setSchedule} />
+      </div>
+
+      <div className="space-y-2">
+        {items.map((item, index) => (
+          <ChecklistItemField
+            key={item.id}
+            value={item.text}
+            onChange={(text) => updateItem(item.id, text)}
+            onRemove={() => removeItem(item.id)}
+            autoFocus={index === 0}
+          />
+        ))}
+        <Button type="button" variant="ghost" onClick={addItem}>Add Item</Button>
+      </div>
+
+      <div className="text-right">
+        <Button type="submit" disabled={!title.trim() || items.length === 0}>Save Checklist</Button>
+      </div>
+    </form>
+  )
+}

--- a/client/src/components/checklists/ChecklistItemField.tsx
+++ b/client/src/components/checklists/ChecklistItemField.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { X } from 'lucide-react'
+
+export interface ChecklistItemFieldProps {
+  value: string
+  onChange: (value: string) => void
+  onRemove: () => void
+  autoFocus?: boolean
+}
+
+export const ChecklistItemField: React.FC<ChecklistItemFieldProps> = ({
+  value,
+  onChange,
+  onRemove,
+  autoFocus,
+}) => (
+  <div className="flex items-center gap-2">
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="flex-1 px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-orange"
+      autoFocus={autoFocus}
+    />
+    <button
+      type="button"
+      onClick={onRemove}
+      className="text-slate-500 hover:text-destructive"
+      aria-label="Remove item"
+    >
+      <X className="w-4 h-4" />
+    </button>
+  </div>
+)

--- a/client/src/components/checklists/ScheduleSelector.tsx
+++ b/client/src/components/checklists/ScheduleSelector.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+export interface ScheduleSelectorProps {
+  value: 'daily' | 'weekly'
+  onChange: (value: 'daily' | 'weekly') => void
+}
+
+export const ScheduleSelector: React.FC<ScheduleSelectorProps> = ({ value, onChange }) => (
+  <div className="flex items-center gap-4">
+    <label className="flex items-center gap-1">
+      <input
+        type="radio"
+        checked={value === 'daily'}
+        onChange={() => onChange('daily')}
+        className="accent-brand-orange"
+      />
+      Daily
+    </label>
+    <label className="flex items-center gap-1">
+      <input
+        type="radio"
+        checked={value === 'weekly'}
+        onChange={() => onChange('weekly')}
+        className="accent-brand-orange"
+      />
+      Weekly
+    </label>
+  </div>
+)

--- a/client/src/components/checklists/index.ts
+++ b/client/src/components/checklists/index.ts
@@ -1,0 +1,4 @@
+export { ChecklistForm } from './ChecklistForm'
+export { ChecklistItemField } from './ChecklistItemField'
+export { ScheduleSelector } from './ScheduleSelector'
+export type { ChecklistFormValues, ChecklistItem } from './ChecklistForm'

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -25,3 +25,7 @@ export type { IconWrapperProps } from './IconWrapper'
 export type { SidebarProps } from './Sidebar'
 export type { HeaderProps } from './Header'
 export type { ContextButtonProps } from './ContextButton' 
+
+// Checklist Components
+export { ChecklistForm, ChecklistItemField, ScheduleSelector } from './checklists'
+export type { ChecklistFormValues, ChecklistItem } from './checklists'

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,16 +1,49 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { ChecklistForm, ChecklistFormValues } from '../components/checklists'
+import useChecklistStore from '../store/useChecklistStore'
+import { Button, Card } from '../components'
 
 // Page Components
 export { Dashboard } from './Dashboard'
 export { Training } from './Training'
 
 // Placeholder pages for navigation
-export const Checklists: React.FC = () => (
-  <div className="p-8 text-center">
-    <h1 className="text-h1 text-charcoal mb-4">Checklists</h1>
-    <p className="text-slate-600">Checklist management coming in Chunk 3</p>
-  </div>
-)
+export const Checklists: React.FC = () => {
+  const [creating, setCreating] = useState(false)
+  const drafts = useChecklistStore((s) => s.drafts)
+  const addDraft = useChecklistStore((s) => s.addDraft)
+
+  const handleSubmit = (values: ChecklistFormValues) => {
+    addDraft(values)
+    setCreating(false)
+  }
+
+  return (
+    <div className="space-y-section p-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-h1 text-charcoal">Checklists</h1>
+        <Button onClick={() => setCreating((c) => !c)}>
+          {creating ? 'Cancel' : 'New Checklist'}
+        </Button>
+      </div>
+
+      {creating && <ChecklistForm onSubmit={handleSubmit} />}
+
+      <div className="grid gap-4">
+        {drafts.map((d) => (
+          <Card key={d.id} className="p-4">
+            <h3 className="text-h3 mb-1">{d.title}</h3>
+            <p className="text-sm text-slate-600 capitalize">{d.frequency}</p>
+            <p className="text-sm text-slate-600">{d.items.length} items</p>
+          </Card>
+        ))}
+        {drafts.length === 0 && !creating && (
+          <p className="text-slate-600">No checklists yet.</p>
+        )}
+      </div>
+    </div>
+  )
+}
 
 export const Reports: React.FC = () => (
   <div className="p-8 text-center">

--- a/client/src/store/useChecklistStore.ts
+++ b/client/src/store/useChecklistStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { nanoid } from 'nanoid'
+
+export interface ChecklistItem {
+  id: string
+  text: string
+}
+
+export type ChecklistFrequency = 'daily' | 'weekly'
+
+export interface ChecklistDraft {
+  id: string
+  title: string
+  items: ChecklistItem[]
+  frequency: ChecklistFrequency
+}
+
+export interface ChecklistRun {
+  id: string
+  checklistId: string
+  completedAt: string
+}
+
+interface ChecklistStore {
+  drafts: ChecklistDraft[]
+  runs: ChecklistRun[]
+  addDraft: (draft: ChecklistDraft) => void
+  updateDraft: (id: string, partial: Partial<ChecklistDraft>) => void
+  removeDraft: (id: string) => void
+  addRun: (run: ChecklistRun) => void
+}
+
+const useChecklistStore = create<ChecklistStore>()(
+  persist(
+    (set) => ({
+      drafts: [],
+      runs: [],
+      addDraft: (draft) =>
+        set((state) => ({
+          drafts: [...state.drafts, { ...draft, id: draft.id || nanoid() }],
+        })),
+      updateDraft: (id, partial) =>
+        set((state) => ({
+          drafts: state.drafts.map((d) => (d.id === id ? { ...d, ...partial } : d)),
+        })),
+      removeDraft: (id) =>
+        set((state) => ({ drafts: state.drafts.filter((d) => d.id !== id) })),
+      addRun: (run) =>
+        set((state) => ({
+          runs: [...state.runs, { ...run, id: run.id || nanoid() }],
+        })),
+    }),
+    { name: 'checklist-store' }
+  )
+)
+
+export default useChecklistStore


### PR DESCRIPTION
## Summary
- build checklist builder form components
- persist checklist drafts and runs in a new Zustand store
- show checklist management in Checklists page
- export checklist components
- test checklist store and components

## Testing
- `npm run test --workspace=client`
- `npm run lint --workspace=client` *(fails: A config object is using the "env" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68579db1e4f8832db4e618062a773104