### PR TITLE
Add docker compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ The root `package.json` exposes several scripts:
 
 See `package.json` for additional scripts such as `dev:client`, `dev:server`, and more.
 
+## Docker Compose
+
+The repository includes a `docker-compose.yml` file for running supporting
+services used by the API. Start the stack with:
+
+```bash
+docker compose up -d
+```
+
+This launches a Postgres 15 database and a MinIO instance with credentials that
+match the defaults referenced in the server configuration. Shut everything down
+with `docker compose down` when finished.
+
 ## Design System
 
 Details about the component library and design system can be found in [`client/src/components/README.md`](client/src/components/README.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: kitchencoach_dev
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+
+volumes:
+  db_data:
+  minio_data:


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with `db` and `minio` services
- document how to run the compose stack in the README

## Testing
- `npm test` *(fails: trainingRoutes.test.ts fails)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_68579db3f568832db3e8f008db513e3d