### PR TITLE
Add auth and checklist API

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,9 @@
     "postgres": "^3.4.3",
     "@neondatabase/serverless": "^0.7.2",
     "zod": "^3.22.4",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.4",
@@ -36,6 +38,8 @@
     "drizzle-kit": "^0.20.6",
     "vitest": "^1.0.4",
     "supertest": "^6.3.3",
-    "@types/supertest": "^6.0.2"
+    "@types/supertest": "^6.0.2",
+    "@types/bcryptjs": "^2.4.6",
+    "@types/jsonwebtoken": "^9.0.5"
   }
-} 
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,8 @@ import express from 'express'
 import cors from 'cors'
 import helmet from 'helmet'
 import trainingRoutes from './routes/training'
+import authRoutes from './routes/auth'
+import checklistRoutes from './routes/checklists'
 import { errorHandler } from './middleware/errorHandler'
 
 
@@ -33,7 +35,9 @@ app.get('/health', (_req, res) => {
 })
 
 // API routes
+app.use('/auth', authRoutes)
 app.use('/api/v1/training', trainingRoutes)
+app.use('/api/v1/checklists', checklistRoutes)
 
 app.get('/api/v1/status', (_req, res) => {
   res.json({

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+
+export interface AuthRequest extends Request {
+  user?: { id: string; role: string }
+}
+
+export function authenticate(req: AuthRequest, res: Response, next: NextFunction) {
+  const header = req.headers.authorization
+  if (!header || !header.startsWith('Bearer ')) {
+    return res.status(401).json({ success: false, error: 'Unauthorized' })
+  }
+  const token = header.split(' ')[1]
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as jwt.JwtPayload
+    req.user = { id: payload.sub as string, role: payload.role as string }
+    next()
+  } catch {
+    res.status(401).json({ success: false, error: 'Invalid token' })
+  }
+}
+
+export function authorize(...roles: string[]) {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      return res.status(401).json({ success: false, error: 'Unauthorized' })
+    }
+    if (!roles.includes(req.user.role)) {
+      return res.status(403).json({ success: false, error: 'Forbidden' })
+    }
+    next()
+  }
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import { DbAuthService } from '../services/dbAuthService'
+import type { AuthService } from '../services/AuthService'
+
+const router = Router()
+const service: AuthService = new DbAuthService()
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1)
+})
+
+router.post('/login', async (req, res, next) => {
+  try {
+    const { email, password } = loginSchema.parse(req.body)
+    const tokens = await service.login(email, password)
+    if (!tokens) {
+      return res.status(401).json({ success: false, error: 'Invalid credentials' })
+    }
+    res.json({ success: true, data: tokens })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
+    }
+    next(err)
+  }
+})
+
+router.post('/refresh', async (req, res) => {
+  const { refreshToken } = req.body as { refreshToken?: string }
+  if (!refreshToken) {
+    return res.status(400).json({ success: false, error: 'refreshToken required' })
+  }
+  const tokens = await service.refresh(refreshToken)
+  if (!tokens) {
+    return res.status(401).json({ success: false, error: 'Invalid token' })
+  }
+  res.json({ success: true, data: tokens })
+})
+
+export default router

--- a/server/src/routes/checklists.ts
+++ b/server/src/routes/checklists.ts
@@ -1,0 +1,81 @@
+import { Router } from 'express'
+import { z } from 'zod'
+import { DbChecklistService } from '../services/dbChecklistService'
+import type { ChecklistService } from '../services/ChecklistService'
+import { authenticate, authorize, AuthRequest } from '../middleware/auth'
+
+const router = Router()
+const service: ChecklistService = new DbChecklistService()
+
+const checklistSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  frequency: z.enum(['daily', 'weekly', 'monthly', 'on_demand']),
+  locationId: z.string().uuid().optional(),
+  isActive: z.boolean().optional()
+})
+
+router.get('/', authenticate, async (_req, res, next) => {
+  try {
+    const data = await service.getChecklists()
+    res.json({ success: true, data })
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.get('/:id', authenticate, async (req, res, next) => {
+  try {
+    const checklist = await service.getChecklist(req.params.id)
+    if (!checklist) {
+      return res.status(404).json({ success: false, error: 'Checklist not found' })
+    }
+    res.json({ success: true, data: checklist })
+  } catch (err) {
+    next(err)
+  }
+})
+
+router.post('/', authenticate, authorize('Manager', 'Supervisor'), async (req: AuthRequest, res, next) => {
+  try {
+    const data = checklistSchema.parse(req.body)
+    const createdBy = req.user!.id
+    const item = await service.createChecklist(data, createdBy)
+    res.status(201).json({ success: true, data: item })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
+    }
+    next(err)
+  }
+})
+
+router.put('/:id', authenticate, authorize('Manager', 'Supervisor'), async (req, res, next) => {
+  try {
+    const data = checklistSchema.partial().parse(req.body)
+    const item = await service.updateChecklist(req.params.id, data)
+    if (!item) {
+      return res.status(404).json({ success: false, error: 'Checklist not found' })
+    }
+    res.json({ success: true, data: item })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
+    }
+    next(err)
+  }
+})
+
+router.delete('/:id', authenticate, authorize('Manager', 'Supervisor'), async (req, res, next) => {
+  try {
+    const ok = await service.deleteChecklist(req.params.id)
+    if (!ok) {
+      return res.status(404).json({ success: false, error: 'Checklist not found' })
+    }
+    res.json({ success: true, message: 'Checklist deleted' })
+  } catch (err) {
+    next(err)
+  }
+})
+
+export default router

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -59,8 +59,6 @@ router.get('/modules/:id', async (req, res, next) => {
 
 router.post('/modules', async (req, res, next) => {
   try {
-    const validated = createModuleSchema.parse(req.body)
-
     const validated = createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & { status?: string }
     const createdBy = (req.headers['x-user-id'] as string) || 'system'
     const module = await service.createModule(validated, createdBy)
@@ -75,8 +73,6 @@ router.post('/modules', async (req, res, next) => {
 
 router.put('/modules/:id', async (req, res, next) => {
   try {
-    const validated = createModuleSchema.partial().parse(req.body)
-
     const validated = createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest
     const module = await service.updateModule(req.params.id, validated)
     if (!module) {

--- a/server/src/services/AuthService.ts
+++ b/server/src/services/AuthService.ts
@@ -1,0 +1,9 @@
+export interface AuthTokens {
+  accessToken: string
+  refreshToken: string
+}
+
+export interface AuthService {
+  login(email: string, password: string): Promise<AuthTokens | null>
+  refresh(refreshToken: string): Promise<AuthTokens | null>
+}

--- a/server/src/services/ChecklistService.ts
+++ b/server/src/services/ChecklistService.ts
@@ -1,0 +1,29 @@
+export interface Checklist {
+  id: string
+  title: string
+  description?: string
+  frequency: 'daily' | 'weekly' | 'monthly' | 'on_demand'
+  locationId?: string | null
+  isActive: boolean
+  createdBy?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateChecklistRequest {
+  title: string
+  description?: string
+  frequency: 'daily' | 'weekly' | 'monthly' | 'on_demand'
+  locationId?: string
+  isActive?: boolean
+}
+
+export interface UpdateChecklistRequest extends Partial<CreateChecklistRequest> {}
+
+export interface ChecklistService {
+  getChecklists(): Promise<Checklist[]>
+  getChecklist(id: string): Promise<Checklist | null>
+  createChecklist(data: CreateChecklistRequest, createdBy?: string): Promise<Checklist>
+  updateChecklist(id: string, data: UpdateChecklistRequest): Promise<Checklist | null>
+  deleteChecklist(id: string): Promise<boolean>
+}

--- a/server/src/services/dbAuthService.ts
+++ b/server/src/services/dbAuthService.ts
@@ -1,0 +1,56 @@
+import { eq } from 'drizzle-orm'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+import { db, users } from '../db'
+import type { AuthService, AuthTokens } from './AuthService'
+
+export class DbAuthService implements AuthService {
+  private issueTokens(user: { id: string; role: string }): AuthTokens {
+    const secret = process.env.JWT_SECRET || 'secret'
+    const accessToken = jwt.sign(
+      { role: user.role },
+      secret,
+      { subject: user.id, expiresIn: '15m' }
+    )
+    const refreshToken = jwt.sign(
+      { role: user.role, type: 'refresh' },
+      secret,
+      { subject: user.id, expiresIn: '7d' }
+    )
+    return { accessToken, refreshToken }
+  }
+
+  async login(email: string, password: string): Promise<AuthTokens | null> {
+    const result = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1)
+
+    const user = result[0] as unknown as { id: string; passwordHash: string; role: string } | undefined
+    if (!user) return null
+
+    const valid = await bcrypt.compare(password, user.passwordHash)
+    if (!valid) return null
+
+    return this.issueTokens(user)
+  }
+
+  async refresh(refreshToken: string): Promise<AuthTokens | null> {
+    try {
+      const secret = process.env.JWT_SECRET || 'secret'
+      const payload = jwt.verify(refreshToken, secret) as jwt.JwtPayload
+      if (payload.type !== 'refresh') return null
+      const result = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, payload.sub as string))
+        .limit(1)
+      const user = result[0] as unknown as { id: string; role: string } | undefined
+      if (!user) return null
+      return this.issueTokens(user)
+    } catch {
+      return null
+    }
+  }
+}

--- a/server/src/services/dbChecklistService.ts
+++ b/server/src/services/dbChecklistService.ts
@@ -1,0 +1,42 @@
+import { desc, eq } from 'drizzle-orm'
+import { db, checklists } from '../db'
+import type {
+  ChecklistService,
+  Checklist,
+  CreateChecklistRequest,
+  UpdateChecklistRequest
+} from './ChecklistService'
+
+export class DbChecklistService implements ChecklistService {
+  async getChecklists(): Promise<Checklist[]> {
+    const items = await db.select().from(checklists).orderBy(desc(checklists.createdAt))
+    return items as unknown as Checklist[]
+  }
+
+  async getChecklist(id: string): Promise<Checklist | null> {
+    const item = await db.select().from(checklists).where(eq(checklists.id, id)).limit(1)
+    return (item[0] as unknown as Checklist) || null
+  }
+
+  async createChecklist(data: CreateChecklistRequest, createdBy?: string): Promise<Checklist> {
+    const [result] = await db
+      .insert(checklists)
+      .values({ ...data, createdBy })
+      .returning()
+    return result as unknown as Checklist
+  }
+
+  async updateChecklist(id: string, data: UpdateChecklistRequest): Promise<Checklist | null> {
+    const [result] = await db
+      .update(checklists)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(checklists.id, id))
+      .returning()
+    return (result as unknown as Checklist) || null
+  }
+
+  async deleteChecklist(id: string): Promise<boolean> {
+    const [result] = await db.delete(checklists).where(eq(checklists.id, id)).returning()
+    return !!result
+  }
+}


### PR DESCRIPTION
## Summary
- add JWT-based login/refresh endpoints
- implement checklist CRUD with RBAC
- mount new routes in the server entry point
- provide database service classes for auth and checklists
- expose auth utilities middleware

## Testing
- `npm test --silent --workspace=server`

------
https://chatgpt.com/codex/tasks/task_e_68579dba47c8832dba71cfddac69d0d5