### PR TITLE
Fix validation variable duplicates

### DIFF
--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -4,7 +4,6 @@ import { DbTrainingService } from '../services/dbTrainingService'
 import { MockTrainingService } from '../services/mockTrainingService'
 import type { TrainingService } from '../services/TrainingService'
 
-import type { CreateTrainingModuleRequest, UpdateTrainingModuleRequest } from '@shared/types/training'
 
 const router = Router()
 
@@ -59,16 +58,7 @@ router.get('/modules/:id', async (req, res, next) => {
 
 router.post('/modules', async (req, res, next) => {
   try {
-    const validated = req.body as CreateTrainingModuleRequest & {
-      status?: string
-    }
-
-    const validated = createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & { status?: string }
-
-    const validated =
-      createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & {
-        status?: string
-      }
+    const validated = createModuleSchema.parse(req.body)
     const createdBy = (req.headers['x-user-id'] as string) || 'system'
     const module = await service.createModule(validated, createdBy)
     res.status(201).json({ success: true, data: module })
@@ -82,12 +72,7 @@ router.post('/modules', async (req, res, next) => {
 
 router.put('/modules/:id', async (req, res, next) => {
   try {
-    const validated = req.body as UpdateTrainingModuleRequest
-
-    const validated = createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest
-
-    const validated =
-      (createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest)
+    const validated = createModuleSchema.partial().parse(req.body)
     const module = await service.updateModule(req.params.id, validated)
     if (!module) {
       return res.status(404).json({ success: false, error: 'Training module not found' })


### PR DESCRIPTION
## Summary
- clean up validation logic for module routes
- remove unused training type imports

## Testing
- `npm test --workspace=server`

------
https://chatgpt.com/codex/tasks/task_e_6857c2886dd4832d921afc2079ef7849