### PR TITLE
Enforce JWT_SECRET presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ The API server requires several environment variables. Create a `.env` file in t
 | `PORT` | Port for the Express server | `3001` |
 | `CLIENT_URL` | Allowed origin for CORS requests | `http://localhost:5173` |
 | `DATABASE_URL` | PostgreSQL connection string | `postgresql://dev:dev@localhost:5432/kitchencoach_dev` |
+| `JWT_SECRET` | Secret key for signing JSON Web Tokens | *(none)* |
 | `NODE_ENV` | Node environment (development/production) | `development` |
+
+The server will throw an error during startup if `JWT_SECRET` is not defined.
 
 Other features such as email or SMS integrations may require additional variables which will be documented alongside those features.
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,5 +1,8 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
+import { requireEnv } from '../utils/requireEnv'
+
+const JWT_SECRET = requireEnv('JWT_SECRET')
 
 export interface AuthRequest extends Request {
   user?: { id: string; role: string }
@@ -12,7 +15,7 @@ export function authenticate(req: AuthRequest, res: Response, next: NextFunction
   }
   const token = header.split(' ')[1]
   try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as jwt.JwtPayload
+    const payload = jwt.verify(token, JWT_SECRET) as jwt.JwtPayload
     req.user = { id: payload.sub as string, role: payload.role as string }
     next()
   } catch {

--- a/server/src/utils/requireEnv.ts
+++ b/server/src/utils/requireEnv.ts
@@ -1,0 +1,7 @@
+export function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+  return value
+}


### PR DESCRIPTION
## Summary
- ensure JWT_SECRET is defined when the server starts
- add small `requireEnv` utility
- document JWT_SECRET environment variable

## Testing
- `npm test` *(fails: trainingRoutes.test.ts has existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857c28b1d38832d9c37d5aa39e414a3