### PR TITLE
Fix training route test

### DIFF
--- a/server/src/__tests__/trainingRoutes.test.ts
+++ b/server/src/__tests__/trainingRoutes.test.ts
@@ -1,18 +1,20 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
 import request from 'supertest'
 import express from 'express'
 
-// set invalid database url before importing routes so db connection fails
-process.env.DATABASE_URL = 'postgresql://invalidHost:5432/invalidDb'
-
-import trainingRoutes from '../routes/training'
-
-const app = express()
-app.use(express.json())
-app.use('/api/v1/training', trainingRoutes)
+// Use the mock training service by ensuring DATABASE_URL is unset before loading the routes
+const originalDbUrl = process.env.DATABASE_URL
+delete process.env.DATABASE_URL
 
 describe('Training routes', () => {
   it('GET /api/v1/training/modules returns modules from mock service', async () => {
+    vi.resetModules()
+    const { default: trainingRoutes } = await import('../routes/training')
+
+    const app = express()
+    app.use(express.json())
+    app.use('/api/v1/training', trainingRoutes)
+
     const res = await request(app).get('/api/v1/training/modules')
     expect(res.status).toBe(200)
     expect(Array.isArray(res.body.data)).toBe(true)
@@ -21,3 +23,7 @@ describe('Training routes', () => {
     expect(res.body.data[0]).toHaveProperty('title')
   })
 })
+
+if (originalDbUrl) {
+  process.env.DATABASE_URL = originalDbUrl
+}


### PR DESCRIPTION
## Summary
- ensure the mock training service is loaded in the server tests

## Testing
- `npm test --workspace=server`


------
https://chatgpt.com/codex/tasks/task_e_685837ec6a5c832da84068d5c98ae4c1