### PR TITLE
Improve server error handling

### DIFF
--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,26 +1,27 @@
 import type { Request, Response, NextFunction } from 'express'
 
-interface StatusError {
+interface ApiError {
+  code?: number
   status?: number
   message?: string
+  field?: string
 }
 
 export function errorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction) {
   // eslint-disable-next-line no-console
   console.error('Error:', err)
 
-  let status = 500
-  let message = 'Internal Server Error'
+  const e = (typeof err === 'object' && err !== null) ? (err as ApiError) : {}
+  const code = typeof e.code === 'number' ? e.code : typeof e.status === 'number' ? e.status : 500
+  const message = typeof e.message === 'string' ? e.message : 'Internal Server Error'
 
-  if (typeof err === 'object' && err !== null) {
-    const e = err as StatusError
-    if (typeof e.status === 'number') {
-      status = e.status
-    }
-    if (typeof e.message === 'string' && status !== 500) {
-      message = e.message
-    }
+  const body: { error: { code: number; message: string; field?: string } } = {
+    error: { code, message }
   }
 
-  res.status(status).json({ success: false, error: message })
+  if (typeof e.field === 'string') {
+    body.error.field = e.field
+  }
+
+  res.status(code).json(body)
 }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -23,7 +23,7 @@ router.post('/login', async (req, res, next) => {
     if (err instanceof z.ZodError) {
       return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 

--- a/server/src/routes/checklists.ts
+++ b/server/src/routes/checklists.ts
@@ -20,7 +20,7 @@ router.get('/', authenticate, async (_req, res, next) => {
     const data = await service.getChecklists()
     res.json({ success: true, data })
   } catch (err) {
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -32,7 +32,7 @@ router.get('/:id', authenticate, async (req, res, next) => {
     }
     res.json({ success: true, data: checklist })
   } catch (err) {
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -46,7 +46,7 @@ router.post('/', authenticate, authorize('Manager', 'Supervisor'), async (req: A
     if (err instanceof z.ZodError) {
       return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -62,7 +62,7 @@ router.put('/:id', authenticate, authorize('Manager', 'Supervisor'), async (req,
     if (err instanceof z.ZodError) {
       return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -74,7 +74,7 @@ router.delete('/:id', authenticate, authorize('Manager', 'Supervisor'), async (r
     }
     res.json({ success: true, message: 'Checklist deleted' })
   } catch (err) {
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -40,7 +40,7 @@ router.get('/modules', async (_req, res, next) => {
     const modules = await service.getModules()
     res.json({ success: true, data: modules })
   } catch (err) {
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -52,7 +52,7 @@ router.get('/modules/:id', async (req, res, next) => {
     }
     res.json({ success: true, data: module })
   } catch (err) {
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -61,8 +61,6 @@ router.post('/modules', async (req, res, next) => {
     const validated = createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & {
       status?: string
     }
-
-    const validated = createModuleSchema.parse(req.body)
     const createdBy = (req.headers['x-user-id'] as string) || 'system'
     const module = await service.createModule(validated, createdBy)
     res.status(201).json({ success: true, data: module })
@@ -70,15 +68,13 @@ router.post('/modules', async (req, res, next) => {
     if (err instanceof z.ZodError) {
       return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
 router.put('/modules/:id', async (req, res, next) => {
   try {
     const validated = createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest
-
-    const validated = createModuleSchema.partial().parse(req.body)
     const module = await service.updateModule(req.params.id, validated)
     if (!module) {
       return res.status(404).json({ success: false, error: 'Training module not found' })
@@ -88,7 +84,7 @@ router.put('/modules/:id', async (req, res, next) => {
     if (err instanceof z.ZodError) {
       return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -99,8 +95,8 @@ router.delete('/modules/:id', async (req, res, next) => {
       return res.status(404).json({ success: false, error: 'Training module not found' })
     }
     res.json({ success: true, message: 'Training module deleted successfully' })
-  } catch (err) {
-    next(err)
+ } catch (err) {
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -114,7 +110,7 @@ router.post('/assign', async (req, res, next) => {
     if (err instanceof z.ZodError) {
       return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
     }
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -126,8 +122,8 @@ router.get('/assignments', async (req, res, next) => {
     }
     const assignments = await service.getMyAssignments(userId)
     res.json({ success: true, data: assignments })
-  } catch (err) {
-    next(err)
+ } catch (err) {
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -137,7 +133,7 @@ router.put('/assignments/:id/start', async (req, res, next) => {
     const assignment = await service.startAssignment(req.params.id, userId)
     res.json({ success: true, data: assignment })
   } catch (err) {
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 
@@ -147,7 +143,7 @@ router.put('/assignments/:id/complete', async (req, res, next) => {
     const assignment = await service.completeAssignment(req.params.id, userId, req.body)
     res.json({ success: true, data: assignment })
   } catch (err) {
-    next(err)
+    next({ code: 500, message: (err as Error).message })
   }
 })
 


### PR DESCRIPTION
## Summary
- update error middleware to return `{ error: { code, message, field? } }`
- propagate error code and message in route handlers

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68583db3bc88832db551e1288a3d766c