### PR TITLE
Fix duplicate validation statements

### DIFF
--- a/server/src/__tests__/trainingRoutes.test.ts
+++ b/server/src/__tests__/trainingRoutes.test.ts
@@ -1,14 +1,10 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeAll } from "vitest"
 import request from 'supertest'
 import express from 'express'
 
 // Use the mock training service by ensuring DATABASE_URL is unset before loading the routes
 const originalDbUrl = process.env.DATABASE_URL
 delete process.env.DATABASE_URL
-
-import { describe, it, expect, beforeAll } from "vitest"
-import request from 'supertest'
-import express from 'express'
 
 let app: express.Express
 

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -58,10 +58,6 @@ router.get('/modules/:id', async (req, res, next) => {
 
 router.post('/modules', async (req, res, next) => {
   try {
-    const validated = createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & {
-      status?: string
-    }
-
     const validated = createModuleSchema.parse(req.body)
     const createdBy = (req.headers['x-user-id'] as string) || 'system'
     const module = await service.createModule(validated, createdBy)
@@ -76,8 +72,6 @@ router.post('/modules', async (req, res, next) => {
 
 router.put('/modules/:id', async (req, res, next) => {
   try {
-    const validated = createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest
-
     const validated = createModuleSchema.partial().parse(req.body)
     const module = await service.updateModule(req.params.id, validated)
     if (!module) {

--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -93,7 +93,7 @@ const mockModules = [
 ]
 
 export class MockTrainingService implements TrainingService {
-  private modules = [...mockModules]
+  private modules: TrainingModule[] = [...(mockModules as TrainingModule[])]
 
   async getModules(): Promise<TrainingModuleListItem[]> {
     // Simulate API delay
@@ -119,13 +119,13 @@ export class MockTrainingService implements TrainingService {
 
   async createModule(data: CreateTrainingModuleRequest & { status?: string }): Promise<TrainingModule> {
     await new Promise(resolve => setTimeout(resolve, 400))
-    
-    const newModule = {
+    const status: TrainingStatus = (data.status ?? 'draft') as TrainingStatus
+    const newModule: TrainingModule = {
       id: (this.modules.length + 1).toString(),
       title: data.title,
       description: data.description || '',
       content: data.content,
-      status: data.status || 'draft' as const,
+      status,
       estimatedDuration: data.estimatedDuration,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -136,7 +136,7 @@ export class MockTrainingService implements TrainingService {
       }
     }
     
-    this.modules.push(newModule)
+    this.modules.push(newModule as any)
     return newModule
   }
 
@@ -146,13 +146,13 @@ export class MockTrainingService implements TrainingService {
     const moduleIndex = this.modules.findIndex(module => module.id === id)
     if (moduleIndex === -1) return null
     
-    const updatedModule = {
+    const updatedModule: TrainingModule = {
       ...this.modules[moduleIndex],
       ...data,
       updatedAt: new Date().toISOString()
     }
-    
-    this.modules[moduleIndex] = updatedModule
+
+    this.modules[moduleIndex] = updatedModule as any
     return updatedModule
   }
 


### PR DESCRIPTION
## Summary
- remove duplicate validation lines in POST/PUT handlers
- merge duplicate imports in trainingRoutes test
- adjust mock service types

## Testing
- `npx tsc -p server/tsconfig.json --noEmit` *(fails: Cannot find module '@shared/types/training', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68583db34534832d941b3dea9390c652