### PR TITLE
Fix failing server tests

### DIFF
--- a/server/src/__tests__/trainingRoutes.test.ts
+++ b/server/src/__tests__/trainingRoutes.test.ts
@@ -1,14 +1,10 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, beforeAll, vi } from 'vitest'
 import request from 'supertest'
 import express from 'express'
 
 // Use the mock training service by ensuring DATABASE_URL is unset before loading the routes
 const originalDbUrl = process.env.DATABASE_URL
 delete process.env.DATABASE_URL
-
-import { describe, it, expect, beforeAll } from "vitest"
-import request from 'supertest'
-import express from 'express'
 
 let app: express.Express
 

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -61,8 +61,6 @@ router.post('/modules', async (req, res, next) => {
     const validated = createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & {
       status?: string
     }
-
-    const validated = createModuleSchema.parse(req.body)
     const createdBy = (req.headers['x-user-id'] as string) || 'system'
     const module = await service.createModule(validated, createdBy)
     res.status(201).json({ success: true, data: module })
@@ -77,8 +75,6 @@ router.post('/modules', async (req, res, next) => {
 router.put('/modules/:id', async (req, res, next) => {
   try {
     const validated = createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest
-
-    const validated = createModuleSchema.partial().parse(req.body)
     const module = await service.updateModule(req.params.id, validated)
     if (!module) {
       return res.status(404).json({ success: false, error: 'Training module not found' })


### PR DESCRIPTION
## Summary
- remove duplicate imports in server test
- drop redeclared variables in training routes

## Testing
- `npm test --prefix server`
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6858439f4fb4832d85ec90141c0db0cb