### PR TITLE
Fix TypeScript errors

### DIFF
--- a/client/src/components/TrainingModuleDialog.tsx
+++ b/client/src/components/TrainingModuleDialog.tsx
@@ -3,7 +3,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { Button } from './Button'
 import { ModuleStepField } from './ModuleStepField'
-import useTrainingStore, { DraftTrainingModule } from '../store/useTrainingStore'
+import useTrainingStore, { DraftTrainingModule, TrainingStep } from '../store/useTrainingStore'
 import { X, ChevronLeft, ChevronRight } from 'lucide-react'
 import { nanoid } from 'nanoid'
 
@@ -57,12 +57,12 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
       id: nanoid(),
       title: data.title,
       description: data.description || undefined,
-      steps: data.steps.map(s => ({
+      steps: data.steps.map<TrainingStep>((s) => ({
         id: s.id,
         title: s.title,
         blocks: [
           { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? [{ kind: 'media', url: s.mediaUrl, type: 'image' }] : [])
+          ...(s.mediaUrl ? ([{ kind: 'media', url: s.mediaUrl, type: 'image' }] as const) : [])
         ]
       })),
       status: 'draft'
@@ -77,12 +77,12 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
       id: nanoid(),
       title: data.title,
       description: data.description || undefined,
-      steps: data.steps.map(s => ({
+      steps: data.steps.map<TrainingStep>((s) => ({
         id: s.id,
         title: s.title,
         blocks: [
           { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? [{ kind: 'media', url: s.mediaUrl, type: 'image' }] : [])
+          ...(s.mediaUrl ? ([{ kind: 'media', url: s.mediaUrl, type: 'image' }] as const) : [])
         ]
       })),
       status: 'draft'

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { ChecklistForm, ChecklistFormValues } from '../components/checklists'
-import useChecklistStore from '../store/useChecklistStore'
+import useChecklistStore, { ChecklistDraft } from '../store/useChecklistStore'
 import { Button, Card } from '../components'
 
 // Page Components
@@ -14,7 +14,13 @@ export const Checklists: React.FC = () => {
   const addDraft = useChecklistStore((s) => s.addDraft)
 
   const handleSubmit = (values: ChecklistFormValues) => {
-    addDraft(values)
+    const draft: ChecklistDraft = {
+      id: values.id,
+      title: values.title,
+      items: values.items,
+      frequency: values.schedule
+    }
+    addDraft(draft)
     setCreating(false)
   }
 

--- a/server/src/__tests__/trainingRoutes.test.ts
+++ b/server/src/__tests__/trainingRoutes.test.ts
@@ -1,21 +1,11 @@
-import { describe, it, expect, beforeAll, vi } from 'vitest'
-
-
-import { describe, it, expect, beforeAll, vi } from 'vitest'
-
+import { beforeAll, describe, expect, it } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import jwt from 'jsonwebtoken'
-import { beforeAll, describe, expect, it } from 'vitest'
 
 const JWT_SECRET = 'testsecret'
 
-import { describe, it, expect, vi, beforeAll } from "vitest"
-import request from 'supertest'
-import express from 'express'
-
 // Use the mock training service by ensuring DATABASE_URL is unset before loading the routes
-const originalDbUrl = process.env.DATABASE_URL
 delete process.env.DATABASE_URL
 
 let app: express.Express

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -35,8 +35,8 @@ export function authorize(permission: Permission) {
     if (!req.user) {
       return res.status(401).json({ success: false, error: 'Unauthorized' })
     }
-    const perms =
-      rolePermissions[req.user.role as keyof typeof rolePermissions] || []
+    const perms: readonly Permission[] =
+      rolePermissions[req.user.role as keyof typeof rolePermissions] ?? []
     if (!perms.includes(permission)) {
       return res.status(403).json({ success: false, error: 'Forbidden' })
     }

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -5,9 +5,7 @@ import { MockTrainingService } from '../services/mockTrainingService'
 import type { TrainingService } from '../services/TrainingService'
 import type {
   CreateTrainingModuleRequest,
-  UpdateTrainingModuleRequest,
-  AssignTrainingModuleRequest,
-  CompleteTrainingAssignmentRequest,
+  UpdateTrainingModuleRequest
 } from '@shared/types/training'
 import { authenticate, authorize } from '../middleware/auth'
 
@@ -68,8 +66,6 @@ router.get('/modules/:id', authorize('training.read'), async (req, res, next) =>
 
 router.post('/modules', authorize('training.edit'), async (req, res, next) => {
   try {
-    const validated = createModuleSchema.parse(req.body)
-
     const validated = createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & {
       status?: string
     }
@@ -86,9 +82,6 @@ router.post('/modules', authorize('training.edit'), async (req, res, next) => {
 
 router.put('/modules/:id', authorize('training.edit'), async (req, res, next) => {
   try {
-
-    const validated = createModuleSchema.partial().parse(req.body)
-
     const validated = createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest
     const module = await service.updateModule(req.params.id, validated)
     if (!module) {

--- a/server/src/services/dbTrainingService.ts
+++ b/server/src/services/dbTrainingService.ts
@@ -54,7 +54,7 @@ export class DbTrainingService implements TrainingService {
         description: data.description,
         content: data.content,
         estimatedDuration: data.estimatedDuration,
-        status: data.status || 'draft',
+        status: (data.status ?? 'draft') as 'draft' | 'active' | 'archived',
         createdBy
       })
       .returning()
@@ -85,7 +85,7 @@ export class DbTrainingService implements TrainingService {
   }
 
   async assignModule(data: AssignTrainingModuleRequest, assignedBy: string): Promise<TrainingAssignment[]> {
-    const assignments = data.assignedTo.map(userId => ({
+    const assignments = data.assignedTo.map((userId: string) => ({
       moduleId: data.moduleId,
       assignedTo: userId,
       assignedBy,

--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -6,9 +6,8 @@ import {
   CompleteTrainingAssignmentRequest,
   TrainingModule,
   TrainingModuleListItem,
-  TrainingAssignment,
-
-  TrainingAssignmentWithModule
+  TrainingAssignmentWithModule,
+  TrainingStatus
 } from '@shared/types/training'
 
 // Mock data for development
@@ -92,24 +91,32 @@ const mockModules = [
   }
 ]
 
+type ModuleWithCreator = TrainingModule & {
+  creator: {
+    id: string
+    name: string
+    email: string
+  }
+}
+
 export class MockTrainingService implements TrainingService {
-  private modules: TrainingModule[] = [...(mockModules as TrainingModule[])]
+  private modules: ModuleWithCreator[] = [...(mockModules as ModuleWithCreator[])]
 
   async getModules(): Promise<TrainingModuleListItem[]> {
     // Simulate API delay
     await new Promise(resolve => setTimeout(resolve, 300))
     
-    return this.modules.map(module => ({
-      id: module.id,
-      title: module.title,
-      description: module.description,
-      status: module.status,
-      enrollmentCount: 0,
-      estimatedDuration: module.estimatedDuration,
-      createdAt: module.createdAt,
-      updatedAt: module.updatedAt,
-      creator: module.creator
-    }))
+      return this.modules.map(module => ({
+        id: module.id,
+        title: module.title,
+        description: module.description,
+        status: module.status,
+        enrollmentCount: 0,
+        estimatedDuration: module.estimatedDuration,
+        createdAt: module.createdAt,
+        updatedAt: module.updatedAt,
+        creator: module.creator
+      }))
   }
 
   async getModule(id: string): Promise<TrainingModule | null> {
@@ -120,7 +127,7 @@ export class MockTrainingService implements TrainingService {
   async createModule(data: CreateTrainingModuleRequest & { status?: string }): Promise<TrainingModule> {
     await new Promise(resolve => setTimeout(resolve, 400))
     const status: TrainingStatus = (data.status ?? 'draft') as TrainingStatus
-    const newModule: TrainingModule = {
+    const newModule: ModuleWithCreator = {
       id: (this.modules.length + 1).toString(),
       title: data.title,
       description: data.description || '',
@@ -135,8 +142,8 @@ export class MockTrainingService implements TrainingService {
         email: 'user@restaurant.com'
       }
     }
-    
-    this.modules.push(newModule as any)
+
+    this.modules.push(newModule)
     return newModule
   }
 
@@ -146,13 +153,13 @@ export class MockTrainingService implements TrainingService {
     const moduleIndex = this.modules.findIndex(module => module.id === id)
     if (moduleIndex === -1) return null
     
-    const updatedModule: TrainingModule = {
+    const updatedModule: ModuleWithCreator = {
       ...this.modules[moduleIndex],
       ...data,
       updatedAt: new Date().toISOString()
     }
 
-    this.modules[moduleIndex] = updatedModule as any
+    this.modules[moduleIndex] = updatedModule
     return updatedModule
   }
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,13 +3,15 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "../",
+    "rootDirs": ["src", "../shared/src"],
     "paths": {
-      "@shared/*": ["../shared/dist/*"]
+      "@shared/*": ["../shared/src/*"]
     }
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "../shared/src/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- clean up training route tests
- fix TrainingModuleDialog types
- handle ChecklistForm values when adding drafts
- adjust permissions check typing
- clean up training route handlers
- make DB training service types explicit
- restructure mock training service with creator field
- reference shared types from server tsconfig

## Testing
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685845bb6438832db5676e0cd8ac2d1f