### PR TITLE
Fix client build, lint and tests

### DIFF
--- a/client/src/components/CreateModuleModal.tsx
+++ b/client/src/components/CreateModuleModal.tsx
@@ -44,6 +44,7 @@ export const CreateModuleModal: React.FC<CreateModuleModalProps> = ({ isOpen, on
       })
       onClose()
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error('Failed to create module:', error)
       alert('Failed to create training module. Please try again.')
     }

--- a/client/src/components/TrainingModuleDialog.tsx
+++ b/client/src/components/TrainingModuleDialog.tsx
@@ -61,8 +61,10 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
         id: s.id,
         title: s.title,
         blocks: [
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? [{ kind: 'media', url: s.mediaUrl, type: 'image' }] : [])
+          { kind: 'text-md', md: s.content } as const,
+          ...(s.mediaUrl
+            ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
+            : [])
         ]
       })),
       status: 'draft'
@@ -81,8 +83,10 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
         id: s.id,
         title: s.title,
         blocks: [
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? [{ kind: 'media', url: s.mediaUrl, type: 'image' }] : [])
+          { kind: 'text-md', md: s.content } as const,
+          ...(s.mediaUrl
+            ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
+            : [])
         ]
       })),
       status: 'draft'

--- a/client/src/pages/Training.tsx
+++ b/client/src/pages/Training.tsx
@@ -34,6 +34,7 @@ export const Training: React.FC = () => {
       try {
         await deleteModuleMutation.mutateAsync(moduleId)
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.error('Failed to delete training module:', error)
         alert('Failed to delete training module. Please try again.')
       }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -14,7 +14,13 @@ export const Checklists: React.FC = () => {
   const addDraft = useChecklistStore((s) => s.addDraft)
 
   const handleSubmit = (values: ChecklistFormValues) => {
-    addDraft(values)
+    const draft = {
+      id: values.id,
+      title: values.title,
+      items: values.items,
+      frequency: values.schedule,
+    } as const
+    addDraft(draft)
     setCreating(false)
   }
 

--- a/client/src/services/trainingApi.ts
+++ b/client/src/services/trainingApi.ts
@@ -134,7 +134,7 @@ export const trainingApi = {
   },
 
   // Assign training module to users
-  async assignModule(assignmentData: AssignTrainingModuleRequest): Promise<any> {
+  async assignModule(assignmentData: AssignTrainingModuleRequest): Promise<unknown> {
     if (!navigator.onLine) {
       await queueRequest({
         id: nanoid(),
@@ -164,7 +164,7 @@ export const trainingApi = {
   },
 
   // Start training assignment
-  async startAssignment(assignmentId: string): Promise<any> {
+  async startAssignment(assignmentId: string): Promise<unknown> {
     if (!navigator.onLine) {
       await queueRequest({
         id: nanoid(),
@@ -188,7 +188,10 @@ export const trainingApi = {
   },
 
   // Complete training assignment
-  async completeAssignment(assignmentId: string, completionData: CompleteTrainingAssignmentRequest): Promise<any> {
+  async completeAssignment(
+    assignmentId: string,
+    completionData: CompleteTrainingAssignmentRequest
+  ): Promise<unknown> {
     if (!navigator.onLine) {
       await queueRequest({
         id: nanoid(),

--- a/client/src/utils/offline.ts
+++ b/client/src/utils/offline.ts
@@ -8,7 +8,7 @@ interface OfflineDB extends DBSchema {
   }
   query: {
     key: string
-    value: any
+    value: unknown
   }
 }
 
@@ -16,7 +16,7 @@ export interface OfflineRequest {
   id: string
   url: string
   method: string
-  body?: any
+  body?: unknown
   headers?: Record<string, string>
 }
 
@@ -70,6 +70,7 @@ export async function syncQueuedRequests() {
       })
       await db.delete('requests', req.id)
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error('Failed to sync request', err)
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:client": "npm run dev --workspace=client",
     "dev:server": "npm run dev --workspace=server",
-    "build": "npm run build --workspace=client && npm run build --workspace=server",
+    "build": "npm run build --workspace=shared && npm run build --workspace=client && npm run build --workspace=server",
     "build:client": "npm run build --workspace=client",
     "build:server": "npm run build --workspace=server",
     "test": "npm run test --workspace=client && npm run test --workspace=server",

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -147,10 +147,12 @@ async function seed() {
     }
   ]);
 
+  // eslint-disable-next-line no-console
   console.log('✅ Database seeded');
 }
 
 seed().then(() => process.exit(0)).catch(err => {
+  // eslint-disable-next-line no-console
   console.error('Seed failed', err);
   process.exit(1);
 });

--- a/server/src/__tests__/authAndChecklistRoutes.test.ts
+++ b/server/src/__tests__/authAndChecklistRoutes.test.ts
@@ -34,12 +34,19 @@ vi.mock('../services/dbChecklistService', () => {
       ]
       async getChecklists() { return this.items }
       async getChecklist(id: string) { return this.items.find(i => i.id === id) || null }
-      async createChecklist(data: any) {
+      async createChecklist(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: any
+      ) {
         const item = { ...data, id: '2', createdAt: 'now', updatedAt: 'now' }
         this.items.push(item)
         return item
       }
-      async updateChecklist(id: string, data: any) {
+      async updateChecklist(
+        id: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: any
+      ) {
         const item = this.items.find(i => i.id === id)
         if (!item) return null
         Object.assign(item, data)

--- a/server/src/__tests__/trainingRoutes.test.ts
+++ b/server/src/__tests__/trainingRoutes.test.ts
@@ -1,22 +1,9 @@
-import { describe, it, expect, beforeAll, vi } from 'vitest'
-
-
-import { describe, it, expect, beforeAll, vi } from 'vitest'
-
 import express from 'express'
 import request from 'supertest'
 import jwt from 'jsonwebtoken'
 import { beforeAll, describe, expect, it } from 'vitest'
 
 const JWT_SECRET = 'testsecret'
-
-import { describe, it, expect, vi, beforeAll } from "vitest"
-import request from 'supertest'
-import express from 'express'
-
-// Use the mock training service by ensuring DATABASE_URL is unset before loading the routes
-const originalDbUrl = process.env.DATABASE_URL
-delete process.env.DATABASE_URL
 
 let app: express.Express
 let tokenManager: string
@@ -49,4 +36,3 @@ describe('training route permissions', () => {
     expect(res.status).toBe(403)
   })
 })
-

--- a/server/src/__tests__/uploadRoutes.test.ts
+++ b/server/src/__tests__/uploadRoutes.test.ts
@@ -19,7 +19,11 @@ beforeEach(async () => {
 describe('Uploads routes', () => {
   it('returns a presigned post', async () => {
     const { createPresignedPost } = await import('@aws-sdk/s3-presigned-post')
-    ;(createPresignedPost as any).mockResolvedValue({
+    ;(
+      createPresignedPost as unknown as {
+        mockResolvedValue: (value: unknown) => void
+      }
+    ).mockResolvedValue({
       url: 'http://localhost:9000/uploads',
       fields: { key: 'test.jpg' }
     })

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -18,7 +18,7 @@ try {
   // Create a mock database for development/testing when no real DB is available
   const mockSql: NeonQueryFunction<boolean, boolean> = (() => {
     throw new Error('Database not configured - using mock for development')
-  }) as any
+  }) as unknown as NeonQueryFunction<boolean, boolean>
   
   db = drizzle(mockSql, { schema })
 }

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -6,8 +6,6 @@ import type { TrainingService } from '../services/TrainingService'
 import type {
   CreateTrainingModuleRequest,
   UpdateTrainingModuleRequest,
-  AssignTrainingModuleRequest,
-  CompleteTrainingAssignmentRequest,
 } from '@shared/types/training'
 import { authenticate, authorize } from '../middleware/auth'
 
@@ -68,8 +66,6 @@ router.get('/modules/:id', authorize('training.read'), async (req, res, next) =>
 
 router.post('/modules', authorize('training.edit'), async (req, res, next) => {
   try {
-    const validated = createModuleSchema.parse(req.body)
-
     const validated = createModuleSchema.parse(req.body) as CreateTrainingModuleRequest & {
       status?: string
     }
@@ -86,9 +82,6 @@ router.post('/modules', authorize('training.edit'), async (req, res, next) => {
 
 router.put('/modules/:id', authorize('training.edit'), async (req, res, next) => {
   try {
-
-    const validated = createModuleSchema.partial().parse(req.body)
-
     const validated = createModuleSchema.partial().parse(req.body) as UpdateTrainingModuleRequest
     const module = await service.updateModule(req.params.id, validated)
     if (!module) {

--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -6,8 +6,7 @@ import {
   CompleteTrainingAssignmentRequest,
   TrainingModule,
   TrainingModuleListItem,
-  TrainingAssignment,
-
+  TrainingStatus,
   TrainingAssignmentWithModule
 } from '@shared/types/training'
 
@@ -136,7 +135,7 @@ export class MockTrainingService implements TrainingService {
       }
     }
     
-    this.modules.push(newModule as any)
+    this.modules.push(newModule)
     return newModule
   }
 
@@ -152,7 +151,7 @@ export class MockTrainingService implements TrainingService {
       updatedAt: new Date().toISOString()
     }
 
-    this.modules[moduleIndex] = updatedModule as any
+    this.modules[moduleIndex] = updatedModule
     return updatedModule
   }
 

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "noEmit": false,
+    "allowImportingTsExtensions": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- restore missing build step for shared workspace
- fix types in `TrainingModuleDialog`
- convert checklist form values before storing draft
- silence expected console calls and clean up lint errors
- use `unknown` instead of `any`
- fix server tests and mock service typings
- allow emitting compiled files from shared workspace

## Testing
- `npm run build --workspace=client`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68584638f8dc832d8b49d66467effcf5