### PR TITLE
Enable PWA service worker

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -28,3 +28,17 @@ function App() {
 ```
 
 Queued requests will be synced automatically once the user is back online.
+
+## PWA Service Worker
+
+The application uses `vite-plugin-pwa` to generate a service worker. API
+requests to `/api/*` are cached with a network-first strategy while static
+assets are cached using a cache-first policy. The service worker is registered
+automatically in `src/main.tsx`.
+
+### Offline Testing
+
+1. Run `npm run build --workspace=client` to generate the production build.
+2. Serve the `dist` directory with `npm run preview --workspace=client`.
+3. Open the app in your browser and then enable offline mode in dev tools.
+4. Navigate previously visited pages to confirm they load from cache.

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './styles/globals.css'
+import { registerSW } from 'virtual:pwa-register'
+
+registerSW({ immediate: true })
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,10 +1,48 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { VitePWA } from 'vite-plugin-pwa'
 import path from 'path'
 
 export default defineConfig({
   plugins: [
-    react()
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      manifest: {
+        name: 'KitchenCoach 2.0',
+        short_name: 'KitchenCoach',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        theme_color: '#ffffff'
+      },
+      workbox: {
+        runtimeCaching: [
+          {
+            urlPattern: /^https?:.*\/api\//,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'api-cache',
+              networkTimeoutSeconds: 10,
+              cacheableResponse: {
+                statuses: [0, 200]
+              }
+            }
+          },
+          {
+            urlPattern: ({ request }) => ['style', 'script', 'image', 'font'].includes(request.destination),
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'assets-cache',
+              expiration: {
+                maxEntries: 60,
+                maxAgeSeconds: 60 * 60 * 24 * 7
+              }
+            }
+          }
+        ]
+      }
+    })
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- configure `vite-plugin-pwa` with caching strategies
- register service worker in the client bootstrap
- document how to test offline support

## Testing
- `npm run build --workspace=client` *(fails: `tsc` errors)*
- `npx vite build` in `client` directory
- `npm test` *(fails: vitest error in server tests)*
- `npm run lint` *(fails: warnings exceed max limit)*

------
https://chatgpt.com/codex/tasks/task_e_68583dbb9208832da17228dfc120420c