### PR TITLE
Fix checklist draft creation

### DIFF
--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -18,15 +18,8 @@ export const Checklists: React.FC = () => {
       id: values.id,
       title: values.title,
       items: values.items,
-      frequency: values.schedule
-    }
-
-    const draft = {
-      id: values.id,
-      title: values.title,
-      items: values.items,
       frequency: values.schedule,
-    } as const
+    }
     addDraft(draft)
     setCreating(false)
   }


### PR DESCRIPTION
## Summary
- merge duplicate `draft` object definitions in `handleSubmit`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: error TS1005 in TrainingModuleDialog.tsx)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c2115320832da04831378bbbbc47