### PR TITLE
Refactor step block mapping

### DIFF
--- a/client/src/components/TrainingModuleDialog.tsx
+++ b/client/src/components/TrainingModuleDialog.tsx
@@ -52,27 +52,27 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
 
   const steps = ['Module Details', 'Build Steps', 'Review & Save']
 
+  const formatSteps = (stepsData: FormData['steps']): TrainingStep[] =>
+    stepsData.map((s) => ({
+      id: s.id,
+      title: s.title,
+      blocks: [
+        { kind: 'text-md', md: s.content } as const,
+        ...(s.mediaUrl
+          ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
+          : [])
+      ]
+    }))
+
   const onSaveDraft = (data: FormData) => {
     const module: DraftTrainingModule = {
       id: nanoid(),
       title: data.title,
       description: data.description || undefined,
-      steps: data.steps.map<TrainingStep>((s) => ({
-        id: s.id,
-        title: s.title,
-        blocks: [
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? ([{ kind: 'media', url: s.mediaUrl, type: 'image' }] as const) : [])
-
-          { kind: 'text-md', md: s.content } as const,
-          ...(s.mediaUrl
-            ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
-            : [])
-        ]
-      })),
+      steps: formatSteps(data.steps),
       status: 'draft'
     }
-    
+
     addDraft(module)
     onOpenChange(false)
   }
@@ -82,22 +82,10 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
       id: nanoid(),
       title: data.title,
       description: data.description || undefined,
-      steps: data.steps.map<TrainingStep>((s) => ({
-        id: s.id,
-        title: s.title,
-        blocks: [
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? ([{ kind: 'media', url: s.mediaUrl, type: 'image' }] as const) : [])
-
-          { kind: 'text-md', md: s.content } as const,
-          ...(s.mediaUrl
-            ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
-            : [])
-        ]
-      })),
+      steps: formatSteps(data.steps),
       status: 'draft'
     }
-    
+
     addDraft(module)
     publish(module.id)
     onOpenChange(false)

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -6,8 +6,6 @@ import type { TrainingService } from '../services/TrainingService'
 import type {
   CreateTrainingModuleRequest,
   UpdateTrainingModuleRequest
-
-  UpdateTrainingModuleRequest,
 } from '@shared/types/training'
 import { authenticate, authorize } from '../middleware/auth'
 

--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -8,9 +8,6 @@ import {
   TrainingModuleListItem,
   TrainingAssignmentWithModule,
   TrainingStatus
-
-  TrainingStatus,
-  TrainingAssignmentWithModule
 } from '@shared/types/training'
 
 // Mock data for development


### PR DESCRIPTION
## Summary
- refactor step block mapping for training module creation
- fix import typos causing server tests to fail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858c2152278832db1d86241f383a35c