### PR TITLE
Standardize permission strings

### DIFF
--- a/server/src/middleware/rbac.ts
+++ b/server/src/middleware/rbac.ts
@@ -2,8 +2,8 @@ import { Response, NextFunction } from 'express'
 import type { AuthRequest } from './auth'
 
 const rolePermissions: Record<string, string[]> = {
-  Manager: ['checklist.edit'],
-  Supervisor: ['checklist.edit'],
+  Manager: ['checklists.edit'],
+  Supervisor: ['checklists.edit'],
   Staff: []
 }
 

--- a/server/src/routes/checklistRuns.ts
+++ b/server/src/routes/checklistRuns.ts
@@ -11,7 +11,7 @@ const service: ChecklistRunService = process.env.DATABASE_URL
   ? new DbChecklistRunService()
   : new MockChecklistRunService()
 
-router.post('/:id/start', authenticate, requirePermission('checklist.edit'), async (req: AuthRequest, res, next) => {
+router.post('/:id/start', authenticate, requirePermission('checklists.edit'), async (req: AuthRequest, res, next) => {
   try {
     const result = await service.startRun(req.params.id, req.user!.id)
     res.json({ success: true, data: result })
@@ -20,7 +20,7 @@ router.post('/:id/start', authenticate, requirePermission('checklist.edit'), asy
   }
 })
 
-router.put('/runs/:id/complete', authenticate, requirePermission('checklist.edit'), async (req: AuthRequest, res, next) => {
+router.put('/runs/:id/complete', authenticate, requirePermission('checklists.edit'), async (req: AuthRequest, res, next) => {
   try {
     const result = await service.completeRun(req.params.id, req.user!.id, req.body)
     res.json({ success: true, data: result })


### PR DESCRIPTION
## Summary
- standardize permission names across middleware
- update checklist run routes to use new permission string

## Testing
- `npm test` *(fails: TrainingModuleDialog.test.tsx parse error)*

------
https://chatgpt.com/codex/tasks/task_e_6858c2171b50832d81ab6e097cdd13ba