### PR TITLE
Add performance trends chart

### DIFF
--- a/client/src/hooks/useCompletionTrends.ts
+++ b/client/src/hooks/useCompletionTrends.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { metricsApi } from '../services/metricsApi'
+
+const QUERY_KEYS = {
+  completionTrends: ['metrics', 'completionTrends'] as const
+}
+
+export function useCompletionTrends() {
+  return useQuery({
+    queryKey: QUERY_KEYS.completionTrends,
+    queryFn: metricsApi.getCompletionTrends,
+    staleTime: 5 * 60 * 1000
+  })
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip } from 'recharts'
+import { format, parseISO } from 'date-fns'
 import { KpiTile } from '../components/KpiTile'
 import { Card } from '../components/Card'
 import { Badge } from '../components/Badge'
-import { TrendingUp, Users, CheckCircle, AlertTriangle, ChevronRight, BarChart3 } from 'lucide-react'
+import { TrendingUp, Users, CheckCircle, AlertTriangle, ChevronRight } from 'lucide-react'
+import { useCompletionTrends } from '../hooks/useCompletionTrends'
 
 export const Dashboard: React.FC = () => {
+  const { data: completionTrends = [], isLoading: trendsLoading } = useCompletionTrends()
   return (
     <div className="space-y-section">
       {/* Page Header */}
@@ -118,20 +122,45 @@ export const Dashboard: React.FC = () => {
         </Card>
       </div>
 
-      {/* Performance Trends */}
-      <Card className="border-dashed">
-        <div className="p-6 md:p-8">
-          <h2 className="text-h2 mb-4">Performance Trends</h2>
-          <div className="h-64 bg-slate-50 rounded-md flex items-center justify-center">
-            <div className="text-center">
-              <div className="w-12 h-12 bg-slate-200 rounded-full flex items-center justify-center mx-auto mb-3">
-                <BarChart3 className="w-6 h-6 text-slate-400" />
-              </div>
-              <p className="text-slate-500">Chart placeholder - Coming in Chunk 3</p>
+        {/* Performance Trends */}
+        <Card className="border-dashed">
+          <div className="p-6 md:p-8">
+            <h2 className="text-h2 mb-4">Performance Trends</h2>
+            <div className="h-64 bg-slate-50 rounded-md">
+              {trendsLoading ? (
+                <div className="flex items-center justify-center h-full text-slate-500">Loading...</div>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={completionTrends} margin={{ left: 8, right: 8, top: 16, bottom: 8 }}>
+                    <defs>
+                      <linearGradient id="trendColor" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#0ea5e9" stopOpacity={0.4} />
+                        <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <XAxis
+                      dataKey="date"
+                      tickFormatter={d => format(parseISO(d), 'MMM')}
+                      tick={{ fontSize: 12 }}
+                      axisLine={false}
+                      tickLine={false}
+                    />
+                    <YAxis domain={[0, 100]} tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
+                    <Tooltip labelFormatter={d => format(parseISO(String(d)), 'MMM yyyy')} />
+                    <Area
+                      type="monotone"
+                      dataKey="completionRate"
+                      stroke="#0ea5e9"
+                      fill="url(#trendColor)"
+                      strokeWidth={2}
+                      activeDot={{ r: 4 }}
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              )}
             </div>
           </div>
-        </div>
-      </Card>
+        </Card>
     </div>
   )
 } 

--- a/client/src/services/metricsApi.ts
+++ b/client/src/services/metricsApi.ts
@@ -1,0 +1,20 @@
+export interface CompletionTrend {
+  date: string
+  completionRate: number
+}
+
+const mockTrends: CompletionTrend[] = [
+  { date: '2024-01-01', completionRate: 75 },
+  { date: '2024-02-01', completionRate: 78 },
+  { date: '2024-03-01', completionRate: 82 },
+  { date: '2024-04-01', completionRate: 86 },
+  { date: '2024-05-01', completionRate: 90 },
+  { date: '2024-06-01', completionRate: 94 }
+]
+
+export const metricsApi = {
+  async getCompletionTrends(): Promise<CompletionTrend[]> {
+    await new Promise(resolve => setTimeout(resolve, 200))
+    return mockTrends
+  }
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,5 @@
 // Shared utilities and types will go here
 // This file is currently empty but ready for future shared code 
 
-export * from './types/training' 
+export * from './types/training'
+export * from './types/metrics'

--- a/shared/src/types/metrics.ts
+++ b/shared/src/types/metrics.ts
@@ -1,0 +1,4 @@
+export interface CompletionTrend {
+  date: string
+  completionRate: number
+}


### PR DESCRIPTION
## Summary
- implement mocked metrics API and hook
- replace chart placeholder with responsive Recharts area chart
- export metrics types in shared package

## Testing
- `npm test` *(fails: TrainingModuleDialog.tsx parse error)*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm run type-check` *(fails: TypeScript errors in TrainingModuleDialog.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6858c2969798832d92a2a10adaee1ec0