### PR TITLE
Add Reports and Settings pages

### DIFF
--- a/client/src/components/TrainingModuleDialog.tsx
+++ b/client/src/components/TrainingModuleDialog.tsx
@@ -61,9 +61,6 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
         id: s.id,
         title: s.title,
         blocks: [
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? ([{ kind: 'media', url: s.mediaUrl, type: 'image' }] as const) : [])
-
           { kind: 'text-md', md: s.content } as const,
           ...(s.mediaUrl
             ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
@@ -86,9 +83,6 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
         id: s.id,
         title: s.title,
         blocks: [
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? ([{ kind: 'media', url: s.mediaUrl, type: 'image' }] as const) : [])
-
           { kind: 'text-md', md: s.content } as const,
           ...(s.mediaUrl
             ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { Card, KpiTile } from '../components'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer
+} from 'recharts'
+
+const incidentData = [
+  { day: 'Mon', count: 1 },
+  { day: 'Tue', count: 0 },
+  { day: 'Wed', count: 3 },
+  { day: 'Thu', count: 2 },
+  { day: 'Fri', count: 1 },
+  { day: 'Sat', count: 0 },
+  { day: 'Sun', count: 0 }
+]
+
+export const Reports: React.FC = () => {
+  return (
+    <div className="space-y-section">
+      <div>
+        <h1 className="text-h1 text-charcoal mb-2">Reports</h1>
+        <p className="text-slate-600">Detailed metrics and compliance history</p>
+      </div>
+
+      <div className="mx-auto max-w-[1440px]">
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-6 xl:gap-4">
+          <KpiTile title="Incident Reports" value="3" change="-40%" trend="down" />
+          <KpiTile title="Average Score" value="92%" change="+2%" trend="up" />
+          <KpiTile title="Open Tasks" value="7" change="+1" trend="up" />
+        </div>
+      </div>
+
+      <Card>
+        <div className="p-6 md:p-8">
+          <h2 className="text-h2 mb-4">Incidents This Week</h2>
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={incidentData} margin={{ left: 8, right: 16 }}>
+                <XAxis dataKey="day" stroke="#475569" />
+                <YAxis allowDecimals={false} stroke="#475569" />
+                <Tooltip />
+                <Line type="monotone" dataKey="count" stroke="#f97316" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      </Card>
+
+      <Card className="border-dashed">
+        <div className="p-6">
+          <h2 className="text-h2 mb-4">Recent Reports</h2>
+          <ul className="space-y-2 text-sm text-slate-700">
+            <li className="flex justify-between">
+              <span>Slip in kitchen</span>
+              <span className="text-slate-500">2 days ago</span>
+            </li>
+            <li className="flex justify-between">
+              <span>Incorrect storage temperature</span>
+              <span className="text-slate-500">4 days ago</span>
+            </li>
+            <li className="flex justify-between">
+              <span>Equipment inspection passed</span>
+              <span className="text-slate-500">1 week ago</span>
+            </li>
+          </ul>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react'
+import { Button, Card } from '../components'
+
+export const Settings: React.FC = () => {
+  const [companyName, setCompanyName] = useState('KitchenCoach')
+  const [email, setEmail] = useState('admin@example.com')
+  const [notifications, setNotifications] = useState(true)
+  const [darkMode, setDarkMode] = useState(false)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    // In a real app, save settings here
+    alert('Settings saved')
+  }
+
+  return (
+    <div className="space-y-section">
+      <div>
+        <h1 className="text-h1 text-charcoal mb-2">Settings</h1>
+        <p className="text-slate-600">Manage application preferences</p>
+      </div>
+
+      <Card>
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          <div>
+            <label htmlFor="company" className="block text-sm font-medium mb-1">Company Name</label>
+            <input
+              id="company"
+              value={companyName}
+              onChange={(e) => setCompanyName(e.target.value)}
+              className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-orange"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium mb-1">Admin Email</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-orange"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              id="notifications"
+              type="checkbox"
+              checked={notifications}
+              onChange={(e) => setNotifications(e.target.checked)}
+              className="h-4 w-4 border-slate-300 rounded"
+            />
+            <label htmlFor="notifications" className="text-sm text-slate-700">Enable notifications</label>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              id="darkmode"
+              type="checkbox"
+              checked={darkMode}
+              onChange={(e) => setDarkMode(e.target.checked)}
+              className="h-4 w-4 border-slate-300 rounded"
+            />
+            <label htmlFor="darkmode" className="text-sm text-slate-700">Use dark mode</label>
+          </div>
+
+          <div className="text-right">
+            <Button type="submit">Save Settings</Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  )
+}

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -6,6 +6,8 @@ import { Button, Card } from '../components'
 // Page Components
 export { Dashboard } from './Dashboard'
 export { Training } from './Training'
+export { Reports } from './Reports'
+export { Settings } from './Settings'
 
 // Placeholder pages for navigation
 export const Checklists: React.FC = () => {
@@ -15,13 +17,6 @@ export const Checklists: React.FC = () => {
 
   const handleSubmit = (values: ChecklistFormValues) => {
     const draft: ChecklistDraft = {
-      id: values.id,
-      title: values.title,
-      items: values.items,
-      frequency: values.schedule
-    }
-
-    const draft = {
       id: values.id,
       title: values.title,
       items: values.items,
@@ -58,19 +53,6 @@ export const Checklists: React.FC = () => {
   )
 }
 
-export const Reports: React.FC = () => (
-  <div className="p-8 text-center">
-    <h1 className="text-h1 text-charcoal mb-4">Reports</h1>
-    <p className="text-slate-600">Reporting dashboard coming in Chunk 4</p>
-  </div>
-)
-
-export const Settings: React.FC = () => (
-  <div className="p-8 text-center">
-    <h1 className="text-h1 text-charcoal mb-4">Settings</h1>
-    <p className="text-slate-600">Settings management coming in future chunks</p>
-  </div>
-)
 
 export const NotFound: React.FC = () => (
   <div className="p-8 text-center">

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -6,8 +6,6 @@ import type { TrainingService } from '../services/TrainingService'
 import type {
   CreateTrainingModuleRequest,
   UpdateTrainingModuleRequest
-
-  UpdateTrainingModuleRequest,
 } from '@shared/types/training'
 import { authenticate, authorize } from '../middleware/auth'
 

--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -8,9 +8,6 @@ import {
   TrainingModuleListItem,
   TrainingAssignmentWithModule,
   TrainingStatus
-
-  TrainingStatus,
-  TrainingAssignmentWithModule
 } from '@shared/types/training'
 
 // Mock data for development


### PR DESCRIPTION
## Summary
- add Reports and Settings pages with basic content
- export these components from pages index
- fix TrainingModuleDialog lint issues
- clean up duplicate imports

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module 'virtual:pwa-register')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858c2971700832db114c3b3eeb1ae24