### PR TITLE
Fix parsing errors in TrainingModuleDialog

### DIFF
--- a/client/src/components/TrainingModuleDialog.tsx
+++ b/client/src/components/TrainingModuleDialog.tsx
@@ -62,9 +62,6 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
         title: s.title,
         blocks: [
           { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? ([{ kind: 'media', url: s.mediaUrl, type: 'image' }] as const) : [])
-
-          { kind: 'text-md', md: s.content } as const,
           ...(s.mediaUrl
             ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
             : [])
@@ -87,9 +84,6 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
         title: s.title,
         blocks: [
           { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? ([{ kind: 'media', url: s.mediaUrl, type: 'image' }] as const) : [])
-
-          { kind: 'text-md', md: s.content } as const,
           ...(s.mediaUrl
             ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
             : [])

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -18,15 +18,8 @@ export const Checklists: React.FC = () => {
       id: values.id,
       title: values.title,
       items: values.items,
-      frequency: values.schedule
-    }
-
-    const draft = {
-      id: values.id,
-      title: values.title,
-      items: values.items,
       frequency: values.schedule,
-    } as const
+    }
     addDraft(draft)
     setCreating(false)
   }

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -5,8 +5,6 @@ import { MockTrainingService } from '../services/mockTrainingService'
 import type { TrainingService } from '../services/TrainingService'
 import type {
   CreateTrainingModuleRequest,
-  UpdateTrainingModuleRequest
-
   UpdateTrainingModuleRequest,
 } from '@shared/types/training'
 import { authenticate, authorize } from '../middleware/auth'

--- a/server/src/services/mockTrainingService.ts
+++ b/server/src/services/mockTrainingService.ts
@@ -7,10 +7,7 @@ import {
   TrainingModule,
   TrainingModuleListItem,
   TrainingAssignmentWithModule,
-  TrainingStatus
-
   TrainingStatus,
-  TrainingAssignmentWithModule
 } from '@shared/types/training'
 
 // Mock data for development


### PR DESCRIPTION
## Summary
- remove stray duplicate content block entries in TrainingModuleDialog
- streamline draft creation in Checklists page
- clean up imports in training routes and mock service

## Testing
- `npm run lint --workspace=client`
- `npm run test --workspace=client`
- `npm run test --workspace=server`

------
https://chatgpt.com/codex/tasks/task_e_6858c8dbd2a0832d9986dd5a52cdbf3e