### PR TITLE
Remove duplicate Persister import

### DIFF
--- a/client/src/utils/offline.ts
+++ b/client/src/utils/offline.ts
@@ -5,7 +5,6 @@ import type {
   PersistedClient,
 } from '@tanstack/query-persist-client-core'
 
-import type { Persister, PersistedClient } from '@tanstack/query-persist-client-core'
 
 interface OfflineDB extends DBSchema {
   requests: {


### PR DESCRIPTION
## Summary
- remove duplicate `Persister`/`PersistedClient` import in offline utils

## Testing
- `npm test` *(fails: Transform failed in TrainingModuleDialog.tsx)*
- `npm run lint` *(fails: parsing errors)*
- `npm run type-check` *(fails: TS1005 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68598e89eadc832db9158d8c43a322aa