### PR TITLE
Fix duplicate draft lines in checklist page

### DIFF
--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { ChecklistForm, ChecklistFormValues } from '../components/checklists'
 import useChecklistStore from '../store/useChecklistStore'
+import type { ChecklistDraft } from '../store/useChecklistStore'
 import { Button, Card } from '../components'
 
 // Page Components
@@ -24,16 +25,10 @@ export const Checklists: React.FC = () => {
   const addDraft = useChecklistStore((s) => s.addDraft)
 
   const handleSubmit = (values: ChecklistFormValues) => {
-
-
-    const draft = {
-
     const draft: ChecklistDraft = {
       id: values.id,
       title: values.title,
       items: values.items,
-
-      frequency: values.schedule
       frequency: values.schedule,
     }
     addDraft(draft)


### PR DESCRIPTION
## Summary
- import ChecklistDraft type in checklist page
- remove duplicated `draft` creation and stray `frequency` line

## Testing
- `npm test` *(fails: TrainingModuleDialog.tsx transform error)*

------
https://chatgpt.com/codex/tasks/task_e_68598e8d20d8832d91137c92c0cfd20d