### PR TITLE
Fix TrainingModuleDialog syntax error

### DIFF
--- a/client/src/components/TrainingModuleDialog.tsx
+++ b/client/src/components/TrainingModuleDialog.tsx
@@ -69,28 +69,6 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
       id: nanoid(),
       title: data.title,
       description: data.description || undefined,
-      steps: data.steps.map<TrainingStep>((s) => ({
-        id: s.id,
-        title: s.title,
-        blocks: [
-
-
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const] : [])
-
-          { kind: 'text-md', md: s.content } as const,
-          ...(s.mediaUrl ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const] : [])
-
-
-          { kind: 'text-md', md: s.content } as const,
-
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl
-            ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
-            : [])
-        ]
-      })),
-
       steps: formatSteps(data.steps),
       status: 'draft'
     }
@@ -104,28 +82,6 @@ export const TrainingModuleDialog: React.FC<TrainingModuleDialogProps> = ({
       id: nanoid(),
       title: data.title,
       description: data.description || undefined,
-      steps: data.steps.map<TrainingStep>((s) => ({
-        id: s.id,
-        title: s.title,
-        blocks: [
-
-
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const] : [])
-
-          { kind: 'text-md', md: s.content } as const,
-          ...(s.mediaUrl ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const] : [])
-
-
-          { kind: 'text-md', md: s.content } as const,
-
-          { kind: 'text-md', md: s.content },
-          ...(s.mediaUrl
-            ? [{ kind: 'media', url: s.mediaUrl, type: 'image' } as const]
-            : [])
-        ]
-      })),
-
       steps: formatSteps(data.steps),
       status: 'draft'
     }


### PR DESCRIPTION
## Summary
- fix TrainingModuleDialog map logic
- remove duplicate steps properties

## Testing
- `npm test --workspace=server`
- `npm test --workspace=client`


------
https://chatgpt.com/codex/tasks/task_e_685af08244a0832dbadfecd268f857b5