### PR TITLE
Update README with npm network note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Install all workspace dependencies from the repository root:
 npm ci
 ```
 
+The `npm ci` (or `npm install`) command requires network access to the npm registry
+unless you have cached dependencies locally. Make sure the environment can reach
+the registry or restore a local cache before running it. Scripts such as
+`npm test` depend on dev packages from the registry, including **vitest**.
+
 During development you can start both the client and server with:
 
 ```bash


### PR DESCRIPTION
## Summary
- add network access notes to the getting started section

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8f7cfaf4832dbac74bbc399db5fe