### PR TITLE
Remove sidebar width tokens

### DIFF
--- a/ARCH_MAP.md
+++ b/ARCH_MAP.md
@@ -120,9 +120,6 @@ const config: Config = {
       height: {
         'tile': '140px', 'list-item': '64px', 'touch-target': '44px'
       },
-      width: {
-        'sidebar-collapsed': '56px', 'sidebar-expanded': '240px'
-      },
       maxHeight: { 'list-scroll': '300px' }
     }
   }

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -64,7 +64,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       className={cn(
         'fixed left-0 top-0 h-full bg-white border-r border-slate-200 z-40',
         'transition-all duration-300 ease-in-out',
-        collapsed ? 'w-sidebar-collapsed' : 'w-sidebar-expanded',
+        'w-60',
         className
       )}
     >

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -72,10 +72,6 @@ const config: Config = {
         'touch-target': '44px',
         'touch': '44px',
       },
-      width: {
-        'sidebar-collapsed': '56px',
-        'sidebar-expanded': '240px',
-      },
       maxHeight: {
         'list-scroll': '300px',
       }

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -1736,7 +1736,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       className={cn(
         'fixed left-0 top-0 h-full bg-white border-r border-slate-200 z-40',
         'transition-all duration-300 ease-in-out',
-        collapsed ? 'w-sidebar-collapsed' : 'w-sidebar-expanded',
+        'w-60',
         className
       )}
     >
@@ -5375,10 +5375,6 @@ const config: Config = {
         'touch-target': '44px',
         'touch': '44px',
       },
-      width: {
-        'sidebar-collapsed': '56px',
-        'sidebar-expanded': '240px',
-      },
       maxHeight: {
         'list-scroll': '300px',
       }
@@ -5697,9 +5693,6 @@ const config: Config = {
       },
       height: {
         'tile': '140px', 'list-item': '64px', 'touch-target': '44px'
-      },
-      width: {
-        'sidebar-collapsed': '56px', 'sidebar-expanded': '240px'
       },
       maxHeight: { 'list-scroll': '300px' }
     }


### PR DESCRIPTION
## Summary
- delete sidebar width tokens from tailwind config
- use `w-60` for Sidebar width
- update architecture docs accordingly
- refresh repomix output

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9f3af748832db52281ab8154785b