### PR TITLE
Fix lint/test, remove sidebar collapse

### DIFF
--- a/client/src/__tests__/Sidebar.test.tsx
+++ b/client/src/__tests__/Sidebar.test.tsx
@@ -1,5 +1,5 @@
-import { describe, test, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import { Sidebar } from '../components/Sidebar'
 
@@ -9,16 +9,11 @@ const SidebarWrapper = ({ children }: { children: React.ReactNode }) => (
 )
 
 describe('Sidebar', () => {
-  const mockOnToggle = vi.fn()
 
-  beforeEach(() => {
-    mockOnToggle.mockClear()
-  })
-
-  test('renders expanded sidebar with all navigation items', () => {
+  test('renders sidebar with all navigation items', () => {
     render(
       <SidebarWrapper>
-        <Sidebar collapsed={false} onToggle={mockOnToggle} />
+        <Sidebar />
       </SidebarWrapper>
     )
 
@@ -37,82 +32,22 @@ describe('Sidebar', () => {
     expect(screen.getByText('Version 2.0.0')).toBeInTheDocument()
   })
 
-  test('renders collapsed sidebar with icons only', () => {
+
+
+  test('shows training badge', () => {
     render(
       <SidebarWrapper>
-        <Sidebar collapsed={true} onToggle={mockOnToggle} />
-      </SidebarWrapper>
-    )
-
-    // Brand text should not be visible
-    expect(screen.queryByText('KitchenCoach')).not.toBeInTheDocument()
-    
-    // Navigation text should not be visible
-    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
-    expect(screen.queryByText('Training')).not.toBeInTheDocument()
-    
-    // Version footer should not be visible
-    expect(screen.queryByText('Version 2.0.0')).not.toBeInTheDocument()
-
-    // Icons should still be present (check by aria-label)
-    expect(screen.getByRole('button', { name: /expand sidebar/i })).toBeInTheDocument()
-  })
-
-  test('calls onToggle when toggle button is clicked', () => {
-    render(
-      <SidebarWrapper>
-        <Sidebar collapsed={false} onToggle={mockOnToggle} />
-      </SidebarWrapper>
-    )
-
-    const toggleButton = screen.getByRole('button', { name: /collapse sidebar/i })
-    fireEvent.click(toggleButton)
-
-    expect(mockOnToggle).toHaveBeenCalledTimes(1)
-  })
-
-  test('shows training badge when not collapsed', () => {
-    render(
-      <SidebarWrapper>
-        <Sidebar collapsed={false} onToggle={mockOnToggle} />
+        <Sidebar />
       </SidebarWrapper>
     )
 
     expect(screen.getByText('3')).toBeInTheDocument()
   })
 
-  test('hides training badge when collapsed', () => {
-    render(
-      <SidebarWrapper>
-        <Sidebar collapsed={true} onToggle={mockOnToggle} />
-      </SidebarWrapper>
-    )
-
-    expect(screen.queryByText('3')).not.toBeInTheDocument()
-  })
-
-  test('applies correct aria-label based on collapsed state', () => {
-    const { rerender } = render(
-      <SidebarWrapper>
-        <Sidebar collapsed={false} onToggle={mockOnToggle} />
-      </SidebarWrapper>
-    )
-
-    expect(screen.getByRole('button', { name: /collapse sidebar/i })).toBeInTheDocument()
-
-    rerender(
-      <SidebarWrapper>
-        <Sidebar collapsed={true} onToggle={mockOnToggle} />
-      </SidebarWrapper>
-    )
-
-    expect(screen.getByRole('button', { name: /expand sidebar/i })).toBeInTheDocument()
-  })
-
   test('navigation links have correct href attributes', () => {
     render(
       <SidebarWrapper>
-        <Sidebar collapsed={false} onToggle={mockOnToggle} />
+        <Sidebar />
       </SidebarWrapper>
     )
 
@@ -123,33 +58,27 @@ describe('Sidebar', () => {
     expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/settings')
   })
 
-  test('has proper keyboard navigation support', () => {
+  test('links are focusable', () => {
     render(
       <SidebarWrapper>
-        <Sidebar collapsed={false} onToggle={mockOnToggle} />
+        <Sidebar />
       </SidebarWrapper>
     )
 
-    const toggleButton = screen.getByRole('button', { name: /collapse sidebar/i })
     const dashboardLink = screen.getByRole('link', { name: /dashboard/i })
-
-    // Should be focusable
-    toggleButton.focus()
-    expect(toggleButton).toHaveFocus()
-
     dashboardLink.focus()
     expect(dashboardLink).toHaveFocus()
   })
 
   test('applies custom className when provided', () => {
     const customClass = 'custom-sidebar'
-    render(
+    const { container } = render(
       <SidebarWrapper>
-        <Sidebar collapsed={false} onToggle={mockOnToggle} className={customClass} />
+        <Sidebar className={customClass} />
       </SidebarWrapper>
     )
 
-    const sidebar = screen.getByRole('button', { name: /collapse sidebar/i }).closest('div')?.parentElement
+    const sidebar = container.firstChild as HTMLElement
     expect(sidebar).toHaveClass(customClass)
   })
-}) 
+})

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,20 +1,15 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
-import { 
-  LayoutDashboard, 
-  BookOpen, 
-  ClipboardCheck, 
-  BarChart3, 
-  Settings,
-  ChevronLeft,
-  ChevronRight
+import {
+  LayoutDashboard,
+  BookOpen,
+  ClipboardCheck,
+  BarChart3,
+  Settings
 } from 'lucide-react'
 import { cn } from '../utils/cn'
-import { Button } from './Button'
 
 export interface SidebarProps {
-  collapsed: boolean
-  onToggle: () => void
   className?: string
 }
 
@@ -54,47 +49,23 @@ const navItems: NavItem[] = [
   }
 ]
 
-export const Sidebar: React.FC<SidebarProps> = ({ 
-  collapsed, 
-  onToggle, 
-  className 
-}) => {
+export const Sidebar: React.FC<SidebarProps> = ({ className }) => {
   return (
-    <div 
+    <div
       className={cn(
         'fixed left-0 top-0 h-full bg-white border-r border-slate-200 z-40',
-        'transition-all duration-300 ease-in-out',
-        collapsed ? 'w-sidebar-collapsed' : 'w-sidebar-expanded',
+        'w-sidebar-expanded',
         className
       )}
     >
       {/* Header */}
-      <div className={cn(
-        "h-16 flex items-center border-b border-slate-200",
-        collapsed ? "justify-center px-2" : "justify-between px-4"
-      )}>
-        {!collapsed && (
-          <div className="flex items-center gap-brand-gap">
-            <div className="w-6 h-6 bg-primary rounded-lg flex items-center justify-center">
-              <span className="text-white font-bold text-xs">KC</span>
-            </div>
-            <span className="font-semibold text-charcoal">KitchenCoach</span>
+      <div className="h-16 flex items-center border-b border-slate-200 px-4 justify-between">
+        <div className="flex items-center gap-brand-gap">
+          <div className="w-6 h-6 bg-primary rounded-lg flex items-center justify-center">
+            <span className="text-white font-bold text-xs">KC</span>
           </div>
-        )}
-        
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onToggle}
-          className="p-1.5 hover:bg-slate-100 min-w-touch min-h-touch flex items-center justify-center"
-          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        >
-          {collapsed ? (
-            <ChevronRight className="w-4 h-4" />
-          ) : (
-            <ChevronLeft className="w-4 h-4" />
-          )}
-        </Button>
+          <span className="font-semibold text-charcoal">KitchenCoach</span>
+        </div>
       </div>
 
       {/* Navigation */}
@@ -109,39 +80,26 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 'hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus',
                 'min-w-touch min-h-touch', // Accessibility fix
                 isActive
-                  ? collapsed 
-                    ? 'bg-slate-100 text-primary'
-                    : 'bg-primary/10 text-primary border-r-2 border-primary'
-                  : collapsed
-                    ? 'text-slate-500 hover:text-slate-600 hover:bg-slate-100'
-                    : 'text-slate-600 hover:text-slate-900',
-                collapsed && 'justify-center px-2'
+                  ? 'bg-primary/10 text-primary border-r-2 border-primary'
+                  : 'text-slate-600 hover:text-slate-900'
               )
             }
           >
-            <item.icon className={cn('w-5 h-5', !collapsed && 'mr-3')} />
-            {!collapsed && (
-              <>
-                <span className="flex-1">{item.name}</span>
-                {item.badge && (
-                  <span className="ml-2 px-2 py-0.5 text-xs bg-primary/20 text-primary rounded-full">
-                    {item.badge}
-                  </span>
-                )}
-              </>
+            <item.icon className="w-5 h-5 mr-3" />
+            <span className="flex-1">{item.name}</span>
+            {item.badge && (
+              <span className="ml-2 px-2 py-0.5 text-xs bg-primary/20 text-primary rounded-full">
+                {item.badge}
+              </span>
             )}
           </NavLink>
         ))}
       </nav>
 
       {/* Footer */}
-      {!collapsed && (
-        <div className="px-4 py-4 border-t border-slate-200">
-          <div className="text-xs text-slate-500 text-center">
-            Version 2.0.0
-          </div>
-        </div>
-      )}
+      <div className="px-4 py-4 border-t border-slate-200">
+        <div className="text-xs text-slate-500 text-center">Version 2.0.0</div>
+      </div>
     </div>
   )
-} 
+}

--- a/client/src/layouts/AppLayout.tsx
+++ b/client/src/layouts/AppLayout.tsx
@@ -8,23 +8,16 @@ export interface AppLayoutProps {
 }
 
 export const AppLayout: React.FC<AppLayoutProps> = ({ className }) => {
-  const [sidebarCollapsed, setSidebarCollapsed] = React.useState(false)
-
   return (
     <div className={cn('layout-shell min-h-screen bg-slate-50', className)}>
       {/* Sidebar */}
-      <Sidebar 
-        collapsed={sidebarCollapsed}
-        onToggle={() => setSidebarCollapsed(!sidebarCollapsed)}
-      />
-      
+      <Sidebar />
+
       {/* Main Content Area */}
-      <div 
+      <div
         className={cn(
           'transition-all duration-300 ease-in-out min-h-screen',
-          sidebarCollapsed 
-            ? 'ml-14' // 56px for collapsed sidebar
-            : 'ml-60' // 240px for expanded sidebar
+          'ml-60'
         )}
       >
         {/* Header */}

--- a/client/src/sw.ts
+++ b/client/src/sw.ts
@@ -1,3 +1,5 @@
+/* eslint-env serviceworker */
+/* global ServiceWorkerGlobalScope */
 import { precacheAndRoute } from 'workbox-precaching'
 import { clientsClaim } from 'workbox-core'
 import { syncQueuedRequests } from './utils/offline'

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -2118,23 +2118,16 @@ export interface AppLayoutProps {
 }
 
 export const AppLayout: React.FC<AppLayoutProps> = ({ className }) => {
-  const [sidebarCollapsed, setSidebarCollapsed] = React.useState(false)
-
   return (
     <div className={cn('layout-shell min-h-screen bg-slate-50', className)}>
       {/* Sidebar */}
-      <Sidebar 
-        collapsed={sidebarCollapsed}
-        onToggle={() => setSidebarCollapsed(!sidebarCollapsed)}
-      />
-      
+      <Sidebar />
+
       {/* Main Content Area */}
-      <div 
+      <div
         className={cn(
           'transition-all duration-300 ease-in-out min-h-screen',
-          sidebarCollapsed 
-            ? 'ml-14' // 56px for collapsed sidebar
-            : 'ml-60' // 240px for expanded sidebar
+          'ml-60'
         )}
       >
         {/* Header */}

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -5,14 +5,6 @@ import { MockTrainingService } from '../services/mockTrainingService'
 import type { TrainingService } from '../services/TrainingService'
 import type {
   CreateTrainingModuleRequest,
-
-
-
-
-
-
-  UpdateTrainingModuleRequest,
-
   UpdateTrainingModuleRequest
 } from '@shared/types/training'
 import { authenticate, authorize } from '../middleware/auth'


### PR DESCRIPTION
## Summary
- install node deps so lint and tests run
- remove sidebar collapse logic from `AppLayout` and `Sidebar`
- clean up service worker lint warning
- tidy training routes import
- update repository snapshot
- update sidebar tests

## Testing
- `npm run lint`
- `npm run test`
- `npm run build-storybook --workspace=client`


------
https://chatgpt.com/codex/tasks/task_e_685c9f3c56f4832dab2eae83a529f431