### PR TITLE
Fix lint and test issues

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default [
         ...globals.es2020,
         ...globals.node,
         ...globals.browser,
+        ...globals.serviceworker,
         React: 'readonly',
       },
     },

--- a/server/src/routes/training.ts
+++ b/server/src/routes/training.ts
@@ -5,14 +5,6 @@ import { MockTrainingService } from '../services/mockTrainingService'
 import type { TrainingService } from '../services/TrainingService'
 import type {
   CreateTrainingModuleRequest,
-
-
-
-
-
-
-  UpdateTrainingModuleRequest,
-
   UpdateTrainingModuleRequest
 } from '@shared/types/training'
 import { authenticate, authorize } from '../middleware/auth'


### PR DESCRIPTION
## Summary
- add serviceworker globals so ESLint recognizes ServiceWorker global
- remove duplicate type in server training routes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f133f58ac832d9cf367d500d7f705