### PR TITLE
Integrate Better Auth and login

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ with `docker compose down` when finished.
 ## Design System
 
 Details about the component library and design system can be found in [`client/src/components/README.md`](client/src/components/README.md).
+
+## Authentication
+
+The project uses **Better Auth** for handling user accounts. The client provides
+a `/login` page that posts credentials using Better Auth's React client.
+Server routes leverage Better Auth APIs for login, registration and token refresh.

--- a/client/package.json
+++ b/client/package.json
@@ -39,7 +39,8 @@
     "recharts": "^2.8.0",
     "tailwind-merge": "^2.1.0",
     "zod": "^3.22.4",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "better-auth": "^1.2.10"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.4.6",

--- a/client/src/__tests__/Login.test.tsx
+++ b/client/src/__tests__/Login.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { Login } from '../pages/Login'
+
+const mockMutate = vi.fn()
+vi.mock('../hooks/useAuth', () => ({
+  useLogin: () => ({ mutate: mockMutate, isPending: false })
+}))
+
+describe('Login page', () => {
+  it('submits credentials', () => {
+    render(<Login />)
+    fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'a@b.com' } })
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'pass' } })
+    fireEvent.click(screen.getByRole('button', { name: /login/i }))
+    expect(mockMutate).toHaveBeenCalledWith({ email: 'a@b.com', password: 'pass' })
+  })
+})

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
+import { authClient } from '../lib/auth-client'
 
 const handle = async (url: string, body: unknown) => {
   const res = await fetch(url, {
@@ -13,10 +14,16 @@ const handle = async (url: string, body: unknown) => {
 
 export function useRegister() {
   return useMutation((data: { name: string; email: string; password: string }) =>
-    handle('/auth/register', data)
+    authClient.signUp.email(data)
   )
 }
 
 export function useResetPassword() {
   return useMutation((data: { email: string }) => handle('/auth/reset-password', data))
+}
+
+export function useLogin() {
+  return useMutation((data: { email: string; password: string }) =>
+    authClient.signIn.email(data)
+  )
 }

--- a/client/src/lib/auth-client.ts
+++ b/client/src/lib/auth-client.ts
@@ -1,0 +1,3 @@
+import { createAuthClient } from 'better-auth/react'
+
+export const authClient = createAuthClient()

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react'
+import { useLogin } from '../hooks/useAuth'
+import { Button } from '../components'
+
+export const Login: React.FC = () => {
+  const mutation = useLogin()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    mutation.mutate({ email, password })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-8 space-y-4 max-w-sm mx-auto">
+      <h1 className="text-h1 text-charcoal">Login</h1>
+      <input
+        className="w-full border p-2 rounded"
+        placeholder="Email"
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        className="w-full border p-2 rounded"
+        placeholder="Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <Button type="submit" loading={mutation.isPending}>Login</Button>
+    </form>
+  )
+}

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -14,6 +14,7 @@ export { RunChecklist } from './checklists/RunChecklist'
 
 export { Register } from './Register'
 export { ResetPassword } from './ResetPassword'
+export { Login } from './Login'
 
 export { Reports } from './Reports'
 export { Settings } from './Settings'

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { AppLayout } from './layouts/AppLayout'
-import { Dashboard, Training, TrainingAssignments, TrainingModuleView, Checklists, RunChecklist, Reports, Settings, NotFound, Register, ResetPassword } from './pages'
+import { Dashboard, Training, TrainingAssignments, TrainingModuleView, Checklists, RunChecklist, Reports, Settings, NotFound, Register, ResetPassword, Login } from './pages'
 // import { ModuleEditor } from './pages/training/ModuleEditor' // Removed - using modal instead
 const router = createBrowserRouter([
   {
@@ -50,6 +50,10 @@ const router = createBrowserRouter([
   {
     path: '/register',
     element: <Register />
+  },
+  {
+    path: '/login',
+    element: <Login />
   },
   {
     path: '/reset-password',

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@tanstack/react-query": "^5.80.10",
         "@tanstack/react-query-persist-client": "^5.81.2",
         "axios": "^1.6.2",
+        "better-auth": "^1.2.10",
         "clsx": "^2.0.0",
         "date-fns": "^2.30.0",
         "idb": "^7.1.1",
@@ -4510,6 +4511,21 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@better-auth/utils": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.2.5.tgz",
+      "integrity": "sha512-uI2+/8h/zVsH8RrYdG8eUErbuGBk16rZKQfz8CjxQOyCE6v7BqFYEbFwvOkvl1KbUdxhqOnXp78+uE5h8qVEgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^5.8.2",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.18.tgz",
+      "integrity": "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
@@ -5753,6 +5769,12 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@hono/node-server": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.14.4.tgz",
@@ -6083,6 +6105,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@mdx-js/react": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
@@ -6110,11 +6138,19 @@
         "@types/pg": "8.6.6"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.6.0.tgz",
+      "integrity": "sha512-mIbq/R9QXk5/cTfESb1OKtyFnk7oc1Om/8onA1158K9/OZUQFDEVy55jVTato+xmp3XX6F6Qh0zz0Nc1AxAlRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -6180,6 +6216,64 @@
       "dependencies": {
         "legacy-javascript": "latest",
         "third-party-web": "latest"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.3.16",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.3.16.tgz",
+      "integrity": "sha512-a1viIv3bIahXNssrOIkXZIlI2ePpZaNmR30d4aBL99mu2rO+mT9D6zBsp7H6eROWGtmwv0Ionp5olJurIo09dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.15.tgz",
+      "integrity": "sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.15.tgz",
+      "integrity": "sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz",
+      "integrity": "sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.15.tgz",
+      "integrity": "sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -7410,6 +7504,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.1.0.tgz",
+      "integrity": "sha512-WuHZ/PYvyPJ9nxSzgHtOEjogBhwJfC8xzYkPC+rR/+8chl/ft4ngjiK8kSU5HtRJfczupyOh33b25TjYbvwAcg==",
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.1.1.tgz",
+      "integrity": "sha512-1hsLpRHfSuMB9ee2aAdh0Htza/X3f4djhYISrggqGe3xopNjOcePiSDkDDoPzDYaaMCrbqGP1H2TYU7bgL9PmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -10502,6 +10620,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asn1js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
+      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -10851,6 +10983,37 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/better-auth": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.2.10.tgz",
+      "integrity": "sha512-nEj1RG4DdLUuJiV5CR93ORyPCptGRBwksaPPCkUtGo9ka+UIlTpaiKoTaTqVLLYlqwX4bOj9tJ32oBNdf2G3Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "0.2.5",
+        "@better-fetch/fetch": "^1.1.18",
+        "@noble/ciphers": "^0.6.0",
+        "@noble/hashes": "^1.6.1",
+        "@simplewebauthn/browser": "^13.0.0",
+        "@simplewebauthn/server": "^13.0.0",
+        "better-call": "^1.0.8",
+        "defu": "^6.1.4",
+        "jose": "^5.9.6",
+        "kysely": "^0.28.2",
+        "nanostores": "^0.11.3",
+        "zod": "^3.24.1"
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.0.9.tgz",
+      "integrity": "sha512-Qfm0gjk0XQz0oI7qvTK1hbqTsBY4xV2hsHAxF8LZfUYl3RaECCIifXuVqtPpZJWvlCCMlQSvkvhhyuApGUba6g==",
+      "dependencies": {
+        "@better-fetch/fetch": "^1.1.4",
+        "rou3": "^0.5.1",
+        "set-cookie-parser": "^2.7.1",
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/better-opn": {
       "version": "3.0.2",
@@ -12150,6 +12313,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
     },
     "node_modules/degenerator": {
       "version": "5.0.1",
@@ -15668,6 +15837,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
@@ -15974,6 +16152,15 @@
     "node_modules/kitchencoach-shared": {
       "resolved": "shared",
       "link": true
+    },
+    "node_modules/kysely": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.2.tgz",
+      "integrity": "sha512-4YAVLoF0Sf0UTqlhgQMFU9iQECdah7n+13ANkiuVfRvlK+uI0Etbgd7bVP36dKlG+NXWbhGua8vnGt+sdhvT7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -16852,6 +17039,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.11.4.tgz",
+      "integrity": "sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/natural-compare": {
@@ -18063,6 +18265,24 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -18911,6 +19131,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rou3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.5.1.tgz",
+      "integrity": "sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ==",
+      "license": "MIT"
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -19237,6 +19463,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -21350,7 +21582,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21385,6 +21616,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.8.0",
@@ -23278,6 +23515,7 @@
         "@aws-sdk/s3-presigned-post": "^3.573.0",
         "@neondatabase/serverless": "^0.7.2",
         "bcryptjs": "^2.4.3",
+        "better-auth": "^1.2.10",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "drizzle-orm": "^0.29.1",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "@aws-sdk/s3-presigned-post": "^3.573.0",
     "nodemailer": "^6.9.7",
     "twilio": "^4.15.2"
+    ,"better-auth": "^1.2.10"
   },
   "devDependencies": {
     "@types/node": "^20.10.4",

--- a/server/src/betterAuth.ts
+++ b/server/src/betterAuth.ts
@@ -1,0 +1,7 @@
+import { betterAuth } from 'better-auth'
+
+export const auth = betterAuth({
+  emailAndPassword: {
+    enabled: true
+  }
+})

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,10 +1,10 @@
 import { Router } from 'express'
 import { z } from 'zod'
+import { auth } from '../betterAuth'
 import { DbAuthService } from '../services/dbAuthService'
-import type { AuthService } from '../services/AuthService'
 
 const router = Router()
-const service: AuthService = new DbAuthService()
+const service = new DbAuthService()
 
 const loginSchema = z.object({
   email: z.string().email(),
@@ -24,11 +24,8 @@ const resetSchema = z.object({
 router.post('/login', async (req, res, next) => {
   try {
     const { email, password } = loginSchema.parse(req.body)
-    const tokens = await service.login(email, password)
-    if (!tokens) {
-      return res.status(401).json({ success: false, error: 'Invalid credentials' })
-    }
-    res.json({ success: true, data: tokens })
+    const data = await auth.api.signInEmail({ body: { email, password } })
+    res.json({ success: true, data })
   } catch (err) {
     if (err instanceof z.ZodError) {
       return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
@@ -40,11 +37,8 @@ router.post('/login', async (req, res, next) => {
 router.post('/register', async (req, res, next) => {
   try {
     const { name, email, password } = registerSchema.parse(req.body)
-    const tokens = await service.register(name, email, password)
-    if (!tokens) {
-      return res.status(409).json({ success: false, error: 'Email already in use' })
-    }
-    res.status(201).json({ success: true, data: tokens })
+    const data = await auth.api.signUpEmail({ body: { name, email, password } })
+    res.status(201).json({ success: true, data })
   } catch (err) {
     if (err instanceof z.ZodError) {
       return res.status(400).json({ success: false, error: 'Validation failed', details: err.errors })
@@ -71,11 +65,12 @@ router.post('/refresh', async (req, res) => {
   if (!refreshToken) {
     return res.status(400).json({ success: false, error: 'refreshToken required' })
   }
-  const tokens = await service.refresh(refreshToken)
-  if (!tokens) {
-    return res.status(401).json({ success: false, error: 'Invalid token' })
+  try {
+    const data = await auth.api.refreshToken({ body: { refreshToken } })
+    res.json({ success: true, data })
+  } catch {
+    res.status(401).json({ success: false, error: 'Invalid token' })
   }
-  res.json({ success: true, data: tokens })
 })
 
 export default router


### PR DESCRIPTION
## Summary
- add Better Auth packages
- implement `authClient` and login hook
- create Login page and route
- use Better Auth APIs in server auth routes
- document authentication

## Testing
- `npm test` *(fails: Cannot find package 'pathe')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ca5bbe78c832d913b00a33bd7a0dd