### PR TITLE
Fix refresh token route

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -60,17 +60,6 @@ router.post('/reset-password', async (req, res, next) => {
   }
 })
 
-router.post('/refresh', async (req, res) => {
-  const { refreshToken } = req.body as { refreshToken?: string }
-  if (!refreshToken) {
-    return res.status(400).json({ success: false, error: 'refreshToken required' })
-  }
-  try {
-    const data = await auth.api.refreshToken({ body: { refreshToken } })
-    res.json({ success: true, data })
-  } catch {
-    res.status(401).json({ success: false, error: 'Invalid token' })
-
 router.post('/refresh', async (req, res, next) => {
   try {
     const { refreshToken } = req.body as { refreshToken?: string }


### PR DESCRIPTION
## Summary
- remove old unfinished refresh endpoint
- keep single refresh endpoint using `service.refresh`

## Testing
- `npm run lint --workspace=server`
- `npm run test --workspace=server` *(fails: expected 500 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_686abd35e050832d9f15f7e5417888f1