### PR TITLE
Fix duplicate useLogin hook

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,5 +1,4 @@
 import { useMutation } from '@tanstack/react-query'
-import { setAuthTokens } from '../utils/auth'
 
 import { authClient } from '../lib/auth-client'
 
@@ -20,15 +19,6 @@ export function useRegister() {
   )
 }
 
-export function useLogin() {
-  return useMutation(async (data: { email: string; password: string }) => {
-    const result = await handle('/auth/login', data)
-    if (result?.data?.accessToken && result?.data?.refreshToken) {
-      setAuthTokens(result.data.accessToken, result.data.refreshToken)
-    }
-    return result
-  })
-}
 
 export function useResetPassword() {
   return useMutation((data: { email: string }) => handle('/auth/reset-password', data))


### PR DESCRIPTION
## Summary
- remove custom fetch version of `useLogin`
- rely on `authClient.signIn.email` for login

## Testing
- `npm run lint --workspace=client` *(fails: ServiceWorkerGlobalScope and unused variable errors)*
- `npm run type-check --workspace=client` *(fails to compile TS)*

------
https://chatgpt.com/codex/tasks/task_e_686abd36cb28832db444191edda144d9