### PR TITLE
Remove duplicate login route

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -62,6 +62,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "fake-indexeddb": "^6.0.1",
     "jsdom": "^26.1.0",
     "postcss": "^8.4.32",
     "storybook": "^8.4.6",

--- a/client/src/__tests__/setup.ts
+++ b/client/src/__tests__/setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom'
 import { cleanup } from '@testing-library/react'
 import { afterEach, expect, vi } from 'vitest'
 import * as matchers from '@testing-library/jest-dom/matchers'
+import 'fake-indexeddb/auto'
 
 // Extend Vitest's expect with Testing Library matchers
 expect.extend(matchers)
@@ -10,6 +11,8 @@ expect.extend(matchers)
 afterEach(() => {
   cleanup()
 })
+
+// fake-indexeddb polyfill provides IDB APIs in Node environment
 
 // @ts-ignore - Mock for testing
 global.ResizeObserver = class ResizeObserver {

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -58,10 +58,6 @@ const router = createBrowserRouter([
   {
     path: '/reset-password',
     element: <ResetPassword />
-  },
-  {
-    path: '/login',
-    element: <Login />
   }
 ])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "fake-indexeddb": "^6.0.1",
         "jsdom": "^26.1.0",
         "postcss": "^8.4.32",
         "storybook": "^8.4.6",
@@ -13965,6 +13966,16 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {


### PR DESCRIPTION
## Summary
- fix duplicate `/login` route
- add `fake-indexeddb` polyfill for tests
- add `fake-indexeddb` dev dependency

## Testing
- `npm test --workspace=client`

------
https://chatgpt.com/codex/tasks/task_e_686abd3777f0832db1d41f11697aa719