### PR TITLE
Adjust training assignment types

### DIFF
--- a/client/src/pages/training/Assignments.tsx
+++ b/client/src/pages/training/Assignments.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { Button, Card } from '../../components'
 import { useTrainingAssignments, useStartTrainingAssignment, useCompleteTrainingAssignment } from '../../hooks/useTrainingModules'
+import type { TrainingAssignmentWithModule } from '@shared/types/training'
 
 export const TrainingAssignments: React.FC = () => {
-  const { data: assignments = [] } = useTrainingAssignments()
+  const { data: assignments = [] }: { data?: TrainingAssignmentWithModule[] } =
+    useTrainingAssignments()
   const startMutation = useStartTrainingAssignment()
   const completeMutation = useCompleteTrainingAssignment()
 

--- a/client/src/services/trainingApi.ts
+++ b/client/src/services/trainingApi.ts
@@ -3,7 +3,7 @@ import type {
   TrainingModule,
   CreateTrainingModuleRequest,
   UpdateTrainingModuleRequest,
-  TrainingAssignment,
+  TrainingAssignmentWithModule,
   AssignTrainingModuleRequest,
   CompleteTrainingAssignmentRequest
 } from '@shared/types/training'
@@ -134,7 +134,7 @@ export const trainingApi = {
   },
 
   // Get user's training assignments
-  async getMyAssignments(): Promise<TrainingAssignment[]> {
+  async getMyAssignments(): Promise<TrainingAssignmentWithModule[]> {
     const response = await fetch(`${API_BASE}/training/assignments`, {
       headers: {
         'x-user-id': getCurrentUserId(),


### PR DESCRIPTION
## Summary
- expose module info with training assignments
- import `TrainingAssignmentWithModule` in assignment UI

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acd4238e0832d9db814e0d04888e7