### PR TITLE
Fix duplicate useLogin

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,6 +1,4 @@
 import { useMutation } from '@tanstack/react-query'
-import { setAuthTokens } from '../utils/auth'
-
 import { authClient } from '../lib/auth-client'
 
 const handle = async (url: string, body: unknown) => {
@@ -18,16 +16,6 @@ export function useRegister() {
   return useMutation((data: { name: string; email: string; password: string }) =>
     authClient.signUp.email(data)
   )
-}
-
-export function useLogin() {
-  return useMutation(async (data: { email: string; password: string }) => {
-    const result = await handle('/auth/login', data)
-    if (result?.data?.accessToken && result?.data?.refreshToken) {
-      setAuthTokens(result.data.accessToken, result.data.refreshToken)
-    }
-    return result
-  })
 }
 
 export function useResetPassword() {


### PR DESCRIPTION
## Summary
- remove the old `useLogin` definition
- keep the version that uses the Better Auth client

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686acd417c44832dbe7d98feb16c9ee4