### PR TITLE
Fix auth headers generation

### DIFF
--- a/client/src/services/trainingApi.ts
+++ b/client/src/services/trainingApi.ts
@@ -13,9 +13,13 @@ import { nanoid } from 'nanoid'
 
 const API_BASE = '/api/v1'
 
-const authHeaders = () => {
+const authHeaders = (): Record<string, string> => {
+  const headers: Record<string, string> = {}
   const token = getAccessToken()
-  return token ? { Authorization: `Bearer ${token}` } : {}
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+  return headers
 }
 
 // Helper function to handle API responses


### PR DESCRIPTION
## Summary
- build a `Record<string, string>` object in `authHeaders`
- omit `Authorization` header when no token exists

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find eslint package)*
- `npm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686acd433ba4832dbc15815f70593096