### PR TITLE
Add React Native mobile workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KitchenCoach 2.0 Monorepo
 
-This repository contains the web client, server API and shared utilities for the KitchenCoach 2.0 platform. KitchenCoach 2.0 is a restaurant training, safety, and compliance platform delivered as a responsive web application and iPad PWA.
+This repository contains the web client, server API, React Native mobile app and shared utilities for the KitchenCoach 2.0 platform. KitchenCoach 2.0 is a restaurant training, safety, and compliance platform delivered as a responsive web application, iPad PWA and mobile app.
 
 ## Prerequisites
 
@@ -20,10 +20,11 @@ unless you have cached dependencies locally. Make sure the environment can reach
 the registry or restore a local cache before running it. Scripts such as
 `npm test` depend on dev packages from the registry, including **vitest**.
 
-During development you can start both the client and server with:
+During development you can start the client, server, and mobile app with:
 
 ```bash
 npm run dev
+npm run dev:mobile  # Starts the React Native app
 ```
 
 After installing, you can run linting and tests from the repository root:
@@ -66,7 +67,7 @@ The server will throw an error during startup if `JWT_SECRET` is not defined.
 
 Other features such as email or SMS integrations may require additional variables which will be documented alongside those features.
 
-To run the client or server individually, use `npm run dev:client` or `npm run dev:server`.
+To run the applications individually, use `npm run dev:client`, `npm run dev:server`, or `npm run dev:mobile`.
 
 Build both applications for production:
 
@@ -93,9 +94,10 @@ The root `package.json` exposes several scripts:
 | Script | Description |
 | --- | --- |
 | `dev` | Starts client and server concurrently. |
-| `build` | Builds the client and server applications. |
+| `dev:mobile` | Starts the React Native mobile app. |
+| `build` | Builds the client, server and mobile applications. |
 | `test` | Runs tests for all workspaces. |
-| `lint` | Runs ESLint for the client and server. |
+| `lint` | Runs ESLint for the client, server and mobile app. |
 
 See `package.json` for additional scripts such as `dev:client`, `dev:server`, and more.
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>KitchenCoach Mobile</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,17 @@
+# KitchenCoach Mobile App
+
+This React Native project provides a starting point for a mobile version of the KitchenCoach platform.
+
+## Prerequisites
+- Install [Expo CLI](https://docs.expo.dev/get-started/installation/) globally with `npm install -g expo-cli`.
+
+## Development
+
+From the repository root, install dependencies and start the Expo server:
+
+```bash
+npm install  # or npm ci
+npm run dev:mobile
+```
+
+Open the Expo Go app on your device or emulator to view the mobile app.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "KitchenCoachNative",
+    "slug": "kitchencoach-native",
+    "version": "1.0.0",
+    "sdkVersion": "50.0.0",
+    "platforms": ["ios", "android"],
+    "entryPoint": "index.js"
+  }
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "kitchencoach-mobile",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0"
+  }
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/package.json
+++ b/package.json
@@ -7,23 +7,26 @@
   "workspaces": [
     "client",
     "server",
-    "shared"
+    "shared",
+    "mobile"
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
+    "dev:mobile": "npm run start --workspace=mobile",
     "dev:client": "npm run dev --workspace=client",
     "dev:server": "npm run dev --workspace=server",
-    "build": "npm run build --workspace=shared && npm run build --workspace=client && npm run build --workspace=server",
+    "build": "npm run build --workspace=shared && npm run build --workspace=client && npm run build --workspace=server && npm run build --workspace=mobile",
     "build:client": "npm run build --workspace=client",
     "build:server": "npm run build --workspace=server",
-    "test": "npm run test --workspace=client && npm run test --workspace=server",
+    "build:mobile": "npm run build --workspace=mobile",
+    "test": "npm run test --workspace=client && npm run test --workspace=server && npm run test --workspace=mobile",
     "test:coverage": "npm run test -- --coverage --workspace=client",
-    "lint": "npm run lint --workspace=client && npm run lint --workspace=server",
-    "lint:fix": "npm run lint -- --fix --workspace=client && npm run lint -- --fix --workspace=server",
-    "type-check": "npm run type-check --workspace=client && npm run type-check --workspace=server",
+    "lint": "npm run lint --workspace=client && npm run lint --workspace=server && npm run lint --workspace=mobile",
+    "lint:fix": "npm run lint -- --fix --workspace=client && npm run lint -- --fix --workspace=server && npm run lint -- --fix --workspace=mobile",
+    "type-check": "npm run type-check --workspace=client && npm run type-check --workspace=server && npm run type-check --workspace=mobile",
     "quality-check": "npm run lint && npm run type-check && npm run test && npm run audit:prod",
     "audit:prod": "npm audit --audit-level moderate --omit dev",
-    "clean": "npm run clean --workspace=client && npm run clean --workspace=server && rm -rf reports/",
+    "clean": "npm run clean --workspace=client && npm run clean --workspace=server && npm run clean --workspace=mobile && rm -rf reports/",
     "fresh-install": "npm run clean && rm -rf node_modules */node_modules && npm ci",
     "build-storybook": "npm run build-storybook --workspace=client"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,9 @@
     },
     {
       "path": "./shared"
+    },
+    {
+      "path": "./mobile"
     }
   ]
-} 
+}


### PR DESCRIPTION
## Summary
- create new `mobile` workspace with Expo React Native starter
- include `mobile` in workspace config and TypeScript project refs
- add scripts and README instructions for running the mobile app

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740e1a985c832d82a70d8b26a16412